### PR TITLE
Supporting Meltano paginators - Removes deprecated code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ plugins:
           kind: string
         - name: pagination_limit_per_page_param
           kind: string
+        - name: pagination_total_limit_param
+          kind: string
         - name: streams
           kind: array
         - name: name
@@ -134,6 +136,7 @@ provided at the top-level will be the default values for each stream.:
 - `pagination_results_limit`: optional: limits the max number of records. Note: Will cause an exception if the limit is hit (except for the `restapi_header_link_paginator`). This should be used for development purposes to restrict the total number of records returned by the API. Defaults to None.
 - `pagination_next_page_param`: optional: The name of the param that indicates the page/offset. Defaults to None.
 - `pagination_limit_per_page_param`: optional: The name of the param that indicates the limit/per_page. Defaults to None.
+- `pagination_total_limit_param`: optional: The name of the param that indicates the total limit e.g. total, count. Defaults to total
 - `next_page_token_path`: optional: a jsonpath string representing the path to the "next page" token. Defaults to `'$.next_page'` for the `jsonpath_paginator` paginator only otherwise None.
 - `streams`: required: a list of objects that contain the configuration of each stream. See stream-level params below.
 - `path`: optional: see stream-level params below.
@@ -273,6 +276,7 @@ There are additional request styles supported as follows for pagination.
   - `offset` is calculated from the previous response, or not set if there is no previous response
   - `pagination_page_size` - Sets a limit to number of records per page / response. Default `25` records.
   - `pagination_limit_per_page_param` - the name of the API parameter to limit number of records per page. Default parameter name `limit`.
+  - `pagination_total_limit_param` - The name of the param that indicates the total limit e.g. total, count. Defaults to total
   - `next_page_token_path` - Used to locate an appropriate link in the response. Default None - but looks in the `pagination` section of the JSON response by default. Example, jsonpath to get the offset from the NOAA API `'$.metadata.resultset'`.
 - `simple_header_paginator` - This style uses links in the Header Response to locate the next page. Example the `x-next-page` link used by the Gitlab API.
 - `header_link_paginator` - This style uses the default header link paginator from the Meltano SDK.
@@ -456,6 +460,7 @@ export TAP_REST_API_MSDK_HEADERS='{"token": "<enter NOAA token>"}'
 export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.metadata.resultset'
 export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="offset_paginator"
 export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="style1"
+export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "locationcategories", "params": {"limit": "5"}, "path": "/locationcategories", "primary_keys": ["id"], "records_path": "$.results[*]"}]'
 ```
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,22 @@ export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "locationcategories", "params": {"limit": "5"}, "path": "/locationcategories", "primary_keys": ["id"], "records_path": "$.results[*]"}]'
 ```
 
+### DBT API Example
+
+This example uses the `offset paginator` to access the DBT API to return location categories. In this example the offset tokens are not in the default location of `pagination` so the `next_page_token_path` is set to the DBT API offset location in the json response i.e. `'$.metadata.resultset'`. This example also sets a limit parameter in the `streams` to only return 5 records at a time to prove the pagination is working.
+
+```
+# Access Locations Categories objects via the DBT Cloud API
+# Access Gitlab objects via the DBT Cloud API
+export TAP_REST_API_MSDK_API_URL=https://<removed your url>.getdbt.com/api/v2/accounts/<removed account id>
+export TAP_REST_API_MSDK_HEADERS='{"Authorization": "Bearer <removed place in bearer token>"}'
+export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.extra'
+export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="offset_paginator"
+export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="style1"
+export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="total_count"
+export TAP_REST_API_MSDK_STREAMS='[{"name": "jobs", "path": "/jobs", "primary_keys": ["id"], "records_path": "$.data[*]"}]'
+```
+
 ## Usage
 
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "pagination_request_style": "hateoas_body",
+    "pagination_request_style": "jsonpath_paginator",
     "pagination_response_style": "hateoas_body",
     "api_url": "https://myexample_fhir_api_url/base_folder",
     "pagination_page_size": 100,

--- a/meltano.yml
+++ b/meltano.yml
@@ -20,6 +20,12 @@ plugins:
           kind: string
         - name: pagination_page_size
           kind: integer
+        - name: pagination_results_limit
+          kind: integer
+        - name: pagination_next_page_param
+          kind: string
+        - name: pagination_limit_per_page_param
+          kind: string
         - name: streams
           kind: array
         - name: path

--- a/meltano.yml
+++ b/meltano.yml
@@ -26,6 +26,8 @@ plugins:
           kind: string
         - name: pagination_limit_per_page_param
           kind: string
+        - name: pagination_total_limit_param
+          kind: string
         - name: streams
           kind: array
         - name: path

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -8,7 +8,7 @@ import email.utils
 from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from tap_rest_api_msdk.client import RestApiStream
-from tap_rest_api_msdk.utils import flatten_json, compress_dict
+from tap_rest_api_msdk.utils import flatten_json, unnest_dict
 from urllib.parse import urlparse, parse_qsl, parse_qs
 
 
@@ -68,7 +68,7 @@ class RestAPIOffsetPaginator(BaseOffsetPaginator):
         else:
             pagination = response.json().get("pagination", None)
         if pagination:
-            pagination = compress_dict(pagination)
+            pagination = unnest_dict(pagination)
 
         if pagination and all(x in pagination for x in ["offset", "limit"]):
             record_limit = pagination.get(self.pagination_total_limit_param,0)

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -1,13 +1,184 @@
 """Stream type classes for tap-rest-api-msdk."""
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, cast
 
 import requests
+import email.utils
+from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from tap_rest_api_msdk.client import RestApiStream
 from tap_rest_api_msdk.utils import flatten_json
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import urlparse, parse_qsl, parse_qs
+
+
+class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._jsonpath = jsonpath
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to `hasMore` in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self._jsonpath:
+            return next(extract_jsonpath(self._jsonpath, response.json()), None)
+        else:
+            return response.json().get("hasMore", None)
+
+class RestAPIOffsetPaginator(BaseOffsetPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._jsonpath = jsonpath
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to pagination in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self._jsonpath:
+            pagination = next(extract_jsonpath(self._jsonpath, response.json()), None)
+        else:
+            pagination = response.json().get("pagination", None)
+
+        if pagination and all(x in pagination for x in ["offset", "limit"]):
+            record_limit = pagination.get("total",pagination.get("count",0))
+            records_read = pagination["offset"] + pagination["limit"]
+            if records_read <= record_limit:
+                return True
+
+        return False
+
+class RestAPIHeaderLinkPaginator(HeaderLinkPaginator):
+    def __init__(
+        self,
+        *args,
+        pagination_page_size: int = 25,
+        pagination_results_limit: Optional[int] = None,
+        use_fake_since_parameter: Optional[bool] = False,
+        replication_key: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.pagination_page_size = pagination_page_size
+        self.pagination_results_limit = pagination_results_limit
+        self.use_fake_since_parameter = use_fake_since_parameter
+        self.replication_key = replication_key
+
+    def get_next_url(
+        self, response: requests.Response
+    ) -> Optional[Any]:
+        """Return next page parameter(s) for identifying the next page
+           or None if no more pages.
+           
+           Logic based on https://github.com/MeltanoLabs/tap-github
+           
+        Args:
+            response: The most recent response object.
+            pagination_page_size: A limit for records per page. Default=25
+            pagination_results_limit: A limit to the number of pages returned
+            use_fake_since_parameter: A work around for GitHub. default=False
+            replication_key: Key for incremental processing
+
+        Returns:
+            Page Parameters if there are more pages to fetch, else None.
+        """
+        # Exit if the set Record Limit is reached.
+        if (
+            self._page_count
+            and self.pagination_results_limit
+            and (
+                cast(int, self._page_count) * self.pagination_page_size >= self.pagination_results_limit
+            )
+        ):
+            return None
+          
+        # Leverage header links returned by the GitHub API.
+        if "next" not in response.links.keys():
+            return None
+
+        # Exit early if there is no URL in the next links
+        if not response.links.get("next",{}).get("url"):
+            return None
+
+        resp_json = response.json()
+        if isinstance(resp_json, list):
+            results = resp_json
+        else:
+            results = resp_json.get("items")
+
+        # Exit early if the response has no items. ? Maybe duplicative the "next" link check.
+        if not results:
+            return None
+          
+        # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
+        # the "since" parameter out of the box. So we use a workaround here to exit early.
+        # For such streams, we sort by descending dates (most recent first), and paginate
+        # "back in time" until we reach records before our "fake_since" parameter.
+        if self.replication_key and self.use_fake_since_parameter:
+            request_parameters = parse_qs(str(urlparse(response.request.url).query))
+            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
+            try:
+                since = (
+                    request_parameters["fake_since"][0].replace(" ", "+")
+                    if "fake_since" in request_parameters
+                    else ""
+                )
+            except IndexError:
+                return None
+
+            direction = (
+                request_parameters["direction"][0]
+                if "direction" in request_parameters
+                else None
+            )
+
+            # commit_timestamp is a constructed key which does not exist in the raw response
+            replication_date = (
+                results[-1][self.replication_key]
+                if self.replication_key != "commit_timestamp"
+                else results[-1]["commit"]["committer"]["date"]
+            )
+            # exit early if the replication_date is before our since parameter
+            if (
+                since
+                and direction == "desc"
+                and (parse(replication_date) < parse(since))
+            ):
+                return None
+
+        # Use header links returned by the API to return the query parameters.
+        parsed_url = urlparse(response.links["next"]["url"])
+
+        if parsed_url.query:
+            return(parsed_url.query)
+          
+        return None
 
 
 class DynamicStream(RestApiStream):
@@ -29,6 +200,9 @@ class DynamicStream(RestApiStream):
         pagination_request_style: str = "default",
         pagination_response_style: str = "default",
         pagination_page_size: Optional[int] = None,
+        pagination_results_limit: Optional[int] = None,
+        pagination_next_page_param: Optional[str] = None,
+        pagination_limit_per_page_param: Optional[str] = None,
         start_date: Optional[datetime] = None,
         search_parameter: Optional[str] = None,
         search_prefix: Optional[str] = None,
@@ -50,6 +224,9 @@ class DynamicStream(RestApiStream):
             pagination_request_style: see tap.py
             pagination_response_style: see tap.py
             pagination_page_size: see tap.py
+            pagination_results_limit: see tap.py
+            pagination_next_page_param: see tap.py
+            pagination_limit_per_page_param: see tap.py
             start_date: see tap.py
             search_parameter: see tap.py
             search_prefix: see tap.py
@@ -68,23 +245,57 @@ class DynamicStream(RestApiStream):
         self.replication_key = replication_key
         self.except_keys = except_keys
         self.records_path = records_path
-        self.next_page_token_jsonpath = (
-            next_page_token_path  # Or override `get_next_page_token`.
-        )
-        self.pagination_page_size = pagination_page_size
-        get_url_params_styles = {"style1": self._get_url_params_style1,
+        if next_page_token_path:
+            self.next_page_token_jsonpath = next_page_token_path
+        elif pagination_request_style == 'jsonpath_paginator' or pagination_request_style == 'default':
+            self.next_page_token_jsonpath = "$.next_page" # Set default for jsonpath_paginator
+        get_url_params_styles = {"style1": self._get_url_params_offset_style,
+                                 "offset": self._get_url_params_offset_style,
+                                 "page": self._get_url_params_page_style,
+                                 "header_link": self._get_url_params_header_link,
                                  "hateoas_body": self._get_url_params_hateoas_body}
         self.get_url_params = get_url_params_styles.get(  # type: ignore
-            pagination_response_style, self._get_url_params_default
-        )
-        get_next_page_token_styles = {"style1": self._get_next_page_token_style1,
-                                      "hateoas_body": self._get_next_page_token_hateoas_body}
-        self.get_next_page_token = get_next_page_token_styles.get(  # type: ignore
-            pagination_response_style, self._get_next_page_token_default
-        )
+            pagination_response_style, self._get_url_params_page_style
+        ) # Defaults to page_style url_params
+        self.pagination_request_style = pagination_request_style
+        self.pagination_results_limit = pagination_results_limit
+        self.pagination_next_page_param = pagination_next_page_param
+        self.pagination_limit_per_page_param = pagination_limit_per_page_param
         self.start_date = start_date
         self.search_parameter = search_parameter
         self.search_prefix = search_prefix
+        
+        # Setting Pagination Limits
+        if self.pagination_request_style == 'restapi_header_link_paginator':
+            if pagination_page_size:
+                self.pagination_page_size = pagination_page_size
+            else:
+                if self.pagination_limit_per_page_param:
+                    page_limit_param = self.pagination_limit_per_page_param
+                else:
+                    page_limit_param = "per_page"
+                self.pagination_page_size = int(self.params.get(page_limit_param, 25)) # Default to requesting 25 records
+        elif self.pagination_request_style == 'style1' or self.pagination_request_style == 'offset_paginator':
+            if self.pagination_results_limit:
+                self.ABORT_AT_RECORD_COUNT = self.pagination_results_limit # Will raise an exception.
+            if pagination_page_size:
+                self.pagination_page_size = pagination_page_size
+            else:
+                if self.pagination_limit_per_page_param:
+                    page_limit_param = self.pagination_limit_per_page_param
+                else:
+                    page_limit_param = "limit"
+                self.pagination_page_size = int(self.params.get(page_limit_param, 25)) # Default to requesting 25 records
+        else:
+            if self.pagination_results_limit:
+                self.ABORT_AT_RECORD_COUNT = self.pagination_results_limit # Will raise an exception.
+            self.pagination_page_size = pagination_page_size
+
+        # GitHub is missing the "since" parameter on a few endpoints
+        # set this parameter to True if your stream needs to navigate data in descending order
+        # and try to exit early on its own.
+        # This only has effect on streams whose `replication_key` is `updated_at`.
+        self.use_fake_since_parameter = False
 
     @property
     def http_headers(self) -> dict:
@@ -106,102 +317,43 @@ class DynamicStream(RestApiStream):
 
         return headers
 
-    def _get_next_page_token_default(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Optional[str]:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows the default style of getting the next page token from the
-        default path provided in the config or, if that doesn't exist, the header.
-
-        Args:
-            response: the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
+    def get_new_paginator(self):
+        """Return the requested paginator required to retrieve all data from the API.
 
         Returns:
-              A str representing the next page to be queried or `None`.
+              Paginator Class.
 
         """
-        if self.next_page_token_jsonpath:
-            all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
-            )
-            first_match = next(iter(all_matches), None)
-            next_page_token = first_match
+
+        self.logger.info(f"the next_page_token_jsonpath = {self.next_page_token_jsonpath}.")
+
+        if self.pagination_request_style == 'jsonpath_paginator' or self.pagination_request_style == 'default':
+            return JSONPathPaginator(self.next_page_token_jsonpath)
+        elif self.pagination_request_style == 'simple_header_paginator': # Example Gitlab.com
+            return SimpleHeaderPaginator('X-Next-Page')
+        elif self.pagination_request_style == 'header_link_paginator':
+            return HeaderLinkPaginator()
+        elif self.pagination_request_style == 'restapi_header_link_paginator': # Example GitHub.com
+            return RestAPIHeaderLinkPaginator(pagination_page_size=self.pagination_page_size,
+                                              pagination_results_limit=self.pagination_results_limit,
+                                              replication_key=self.replication_key)
+        elif self.pagination_request_style == 'style1' or self.pagination_request_style == 'offset_paginator':
+            return RestAPIOffsetPaginator(start_value=1,
+                                          page_size=self.pagination_page_size,
+                                          jsonpath=self.next_page_token_jsonpath)
+        elif self.pagination_request_style == 'hateoas_paginator':
+            return BaseHATEOASPaginator()
+        elif self.pagination_request_style == 'single_page_paginator':
+            return SinglePagePaginator()
+        elif self.pagination_request_style == 'page_number_paginator':
+            return RestAPIBasePageNumberPaginator(jsonpath=self.next_page_token_jsonpath)
         else:
-            next_page_token = response.headers.get("X-Next-Page", None)
-
-        return next_page_token
-
-    def _get_next_page_token_style1(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Any:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows method of calculating the next page token from the
-        offsets, limits, and totals provided by the API.
-
-        Args:
-            response: required - the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
-
-        Returns:
-              A str representing the next page to be queried or `None`.
-
-        """
-        pagination = response.json().get("pagination", {})
-        if pagination and all(x in pagination for x in ["offset", "limit", "total"]):
-            next_page_token = pagination["offset"] + pagination["limit"]
-            if next_page_token <= pagination["total"]:
-                return next_page_token
-        return None
-
-    def _get_next_page_token_hateoas_body(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Any:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows method of calculating the next page token from the
-        API response body itself following HATEOAS Rest model.
-
-
-        HATEOAS stands for "Hypermedia as the Engine of Application State". See
-        https://en.wikipedia.org/wiki/HATEOAS.
-
-        Args:
-            response: required - the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
-
-        Returns:
-              A str representing the next page to be queried or `None`.
-
-        """
-
-        if self.next_page_token_jsonpath:
-
-            all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
+            self.logger.error(f"Unknown paginator {self.pagination_request_style}. Please declare a valid paginator.")
+            raise ValueError(
+                f"Unknown paginator {self.pagination_request_style}. Please declare a valid paginator."
             )
-            first_match = next(iter(all_matches), None)
-            next_page_token = first_match
 
-            # Setting up the url using next_page_token parameters
-            # for subsequent calls.
-            url_parsed = urlparse(next_page_token)
-            if url_parsed.path == next_page_token:
-                self.path = ""
-            else:
-                self.path=url_parsed.path
-
-        else:
-            next_page_token = response.headers.get("X-Next-Page", None)
-
-        return next_page_token
-
-    def _get_url_params_default(
+    def _get_url_params_page_style(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
@@ -219,13 +371,17 @@ class DynamicStream(RestApiStream):
             for k, v in self.params.items():
                 params[k] = v
         if next_page_token:
-            params["page"] = next_page_token
+            if self.pagination_next_page_param:
+                next_page_parm = self.pagination_next_page_param
+            else:
+                next_page_parm = "page"
+            params[next_page_parm] = next_page_token
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
         return params
 
-    def _get_url_params_style1(
+    def _get_url_params_offset_style(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
@@ -243,12 +399,81 @@ class DynamicStream(RestApiStream):
             for k, v in self.params.items():
                 params[k] = v
         if next_page_token:
-            params["offset"] = next_page_token
+            if self.pagination_next_page_param:
+                next_page_parm = self.pagination_next_page_param
+            else:
+                next_page_parm = "offset"
+            params[next_page_parm] = next_page_token
         if self.pagination_page_size is not None:
-            params["limit"] = self.pagination_page_size
+            if self.pagination_limit_per_page_param:
+                limit_per_page_param = self.pagination_limit_per_page_param
+            else:
+                limit_per_page_param = "limit"
+            params[limit_per_page_param] = self.pagination_page_size
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
+        return params
+      
+    def _get_url_params_header_link(
+        self, context: Optional[Dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+        Logic based on https://github.com/MeltanoLabs/tap-github
+
+        Args:
+            context: optional - the singer context object.
+            next_page_token: optional - the token for the next page of results.
+
+        Returns:
+            An object containing the parameters to add to the request.
+
+        """
+        params: dict = {}
+        if self.params:
+            for k, v in self.params.items():
+                params[k] = v
+        if self.pagination_page_size:
+            pagination_page_size = self.pagination_page_size
+        else:
+            pagination_page_size = 25 # Default to 25 per page if not set
+        if self.pagination_limit_per_page_param:
+            limit_per_page_param = self.pagination_limit_per_page_param
+        else:
+            limit_per_page_param = "per_page"
+        params[limit_per_page_param] = pagination_page_size
+        if next_page_token:
+            request_parameters = parse_qs(str(next_page_token))
+            for k, v in request_parameters.items():
+                params[k] = v            
+
+        if self.replication_key == "updated_at":
+            params["sort"] = "updated"
+            params["direction"] = "desc" if self.use_fake_since_parameter else "asc"
+
+        # Unfortunately the /starred, /stargazers (starred_at) and /events (created_at) endpoints do not support
+        # the "since" parameter out of the box. But we use a workaround in 'get_next_page_token'.
+        elif self.replication_key in ["starred_at", "created_at"]:
+            params["sort"] = "created"
+            params["direction"] = "desc"
+
+        # Warning: /commits endpoint accept "since" but results are ordered by descending commit_timestamp
+        elif self.replication_key == "commit_timestamp":
+            params["direction"] = "desc"
+
+        elif self.replication_key:
+            self.logger.warning(
+                f"The replication key '{self.replication_key}' is not fully supported by this client yet."
+            )
+
+        since = self.get_starting_timestamp(context)
+        since_key = "since" if not self.use_fake_since_parameter else "fake_since"
+        if self.replication_key and since:
+            params[since_key] = since
+            # Leverage conditional requests to save API quotas
+            # https://github.community/t/how-does-if-modified-since-work/139627
+            self._http_headers["If-modified-since"] = email.utils.format_datetime(since)
+
         return params
 
     def get_start_date(
@@ -278,8 +503,8 @@ class DynamicStream(RestApiStream):
             next_page_token: optional - the token for the next page of results.
 
 
-            HATEOAS stands for "Hypermedia as the Engine of Application State". See
-            https://en.wikipedia.org/wiki/HATEOAS.            
+            HATEOAS stands for "Hypermedia as the Engine of Application State".
+             See https://en.wikipedia.org/wiki/HATEOAS.            
 
             Note: Under the HATEOAS model, the returned token contains all the 
             required parameters for the subsequent call. The function splits the
@@ -298,6 +523,11 @@ class DynamicStream(RestApiStream):
         if self.params:
             for k, v in self.params.items():
                 params[k] = v
+                
+        # Set Pagination Limits if required.
+        if self.pagination_page_size and self.pagination_limit_per_page_param:
+            params[pagination_limit_per_page_param] = self.pagination_page_size
+                
         if next_page_token:
             # Parse the next_page_token for the path and parameters
             url_parsed = urlparse(next_page_token)

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -353,6 +353,13 @@ class TapRestApiMsdk(Tap):
             required=False,
             description="The name of the param that indicates the limit/per_page. Defaults to None",
         ),
+        th.Property(
+            "pagination_total_limit_param",
+            th.StringType,
+            default="total",
+            required=False,
+            description="The name of the param that indicates the total limit e.g. total, count. Defaults to total",
+        ),
     )
 
     # add common properties to top-level properties
@@ -471,6 +478,7 @@ class TapRestApiMsdk(Tap):
                     pagination_results_limit=self.config.get("pagination_results_limit"),
                     pagination_next_page_param=self.config.get("pagination_next_page_param"),
                     pagination_limit_per_page_param=self.config.get("pagination_limit_per_page_param"),
+                    pagination_total_limit_param=self.config.get("pagination_total_limit_param"),
                     schema=schema,
                     start_date=start_date,
                     search_parameter=search_parameter,

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -65,11 +65,11 @@ def flatten_json(obj: dict, except_keys: Optional[list] = None) -> dict:
     flatten(obj, exception_keys=except_keys)
     return out
     
-def compress_dict(dic: dict):
-    result ={}
-    for k,v in dic.items():
+def unnest_dict(d):
+    result = {}
+    for k,v in d.items():
         if isinstance(v, dict):
-            compress_dict(v)
+            result.update(unnest_dict(v))
         else:
-            result.update({k:v})
+            result[k] = v
     return result

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -64,3 +64,12 @@ def flatten_json(obj: dict, except_keys: Optional[list] = None) -> dict:
 
     flatten(obj, exception_keys=except_keys)
     return out
+    
+def compress_dict(dic: dict):
+    result ={}
+    for k,v in dic.items():
+        if isinstance(v, dict):
+            compress_dict(v)
+        else:
+            result.update({k:v})
+    return result


### PR DESCRIPTION
This PR covers changes to support the new Meltano SDK paginators providing wider access to a number of REST Base API's.

The `get_next_page_token` is being deprecated in the Meltano SDK and replaced with `get_new_paginator`, tap-rest-api-msdk now throws up warnings advising of this upcoming deprecation.

This change is built on previous enhancements to support for various Authenticators. It now support for all the different out-of-the-box SDK paginators. The idea of get_new_paginator is to pick a paginator you need to use for the API. Use an appropriate `pagination_request_style` to pick the paginator you require. In most cases this needs to be coupled with an appropriate `paginator_response_style` to process the response and pick the next page token.