### PR TITLE
Feature/add paginators and authenticators

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,13 +464,13 @@ export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "locationcategories", "params": {"limit": "5"}, "path": "/locationcategories", "primary_keys": ["id"], "records_path": "$.results[*]"}]'
 ```
 
-### DBT API Example
+### dbt Cloud API Example
 
-This example uses the `offset paginator` to access the DBT API to return location categories. In this example the offset tokens are not in the default location of `pagination` so the `next_page_token_path` is set to the DBT API offset location in the json response i.e. `'$.metadata.resultset'`. This example also sets a limit parameter in the `streams` to only return 5 records at a time to prove the pagination is working.
+This example uses the `offset paginator` to access the dbt Cloud API to return location categories. In this example the offset tokens are not in the default location of `pagination` so the `next_page_token_path` is set to the dbt API offset location in the json response i.e. `'$.extra'`. This example also sets the streams record_path to `"$.data[*]"` which is the location of the data.
 
 ```
-# Access Locations Categories objects via the DBT Cloud API
-# Access Gitlab objects via the DBT Cloud API
+# Access Locations Categories objects via the dbt Cloud API
+# Access Gitlab objects via the dbt Cloud API
 export TAP_REST_API_MSDK_API_URL=https://<removed your url>.getdbt.com/api/v2/accounts/<removed account id>
 export TAP_REST_API_MSDK_HEADERS='{"Authorization": "Bearer <removed place in bearer token>"}'
 export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.extra'

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ provided at the top-level will be the default values for each stream.:
 - `redirect_uri`: optional: see authentication params below.
 - `oauth_extras`: optional: see authentication params below.
 - `oauth_expiration_secs`: optional: see authentication params below.
+- `aws_credentials`: optional: see authentication params below.
 
 #### Stream level config options. 
 Parameters that appear at the stream-level
@@ -237,6 +238,14 @@ will overwrite their top-level counterparts except where noted below:
 - `oauth_expiration_secs`: optional: Used for OAuth2 authentication method. This optional setting
   is a timer for the expiration of a token in seconds. If not set the OAuth will use the default
   expiration set in the token by the authorization server.
+- `aws_credentials`: optional: A object of Key/Value pairs to support AWS authentication when using the AWS authenticator. While the tap can use AWS [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) environment variables and aws_profiles, the [AWS service code](https://docs.aws.amazon.com/general/latest/gr/rande.html) needs to be specified e.g. `es` for OpenSearch / Elastic Search. By default the requirement to use `use_signed_credentials` is set to true. Config example:
+  ```json
+  { "aws_access_key_id": "my_aws_key_id",
+    "aws_secret_access_key": "my_aws_secret_access_key",
+    "aws_region": "us-east-1",
+    "aws_service": "es",
+    "use_signed_credentials": true}
+  ```
 
 #### Complex Authentication
 
@@ -478,6 +487,21 @@ export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="offset_paginator"
 export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="style1"
 export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="total_count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "jobs", "path": "/jobs", "primary_keys": ["id"], "records_path": "$.data[*]"}]'
+```
+
+### AWS OpenSearch API Example
+
+This example uses the [AWS4Auth](https://github.com/tedder/requests-aws4auth) authenticator to provide signed AWS credentials for the request AWS API. In this example pagination has not been specified, pick appropriate pagination for service. This example also sets the streams record_path to `"$.hits.hits[*]"` which is the location of the data.
+
+Note: The AWS authentication does support [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) environment variables and aws_profiles.
+
+```
+# Access AWS objects via the AWS Open/Elastic Search API
+export TAP_REST_API_MSDK_API_URL="https://<endpoint>.<aws region>.<aws service>.amazonaws.com"
+export TAP_REST_API_MSDK_AWS_CREDENTIALS='{"aws_access_key_id": "<removed aws access key id>", "aws_secret_access_key": "removed aws secret access key>",
+"aws_region": "<aws region e.g. us‑east‑1>", "aws_service": "<aws service e.g. es for opensearch>", "create_signed_credentials": true}'
+export TAP_REST_API_MSDK_AUTH_METHOD='aws'
+export TAP_REST_API_MSDK_STREAMS='[{"name": "resourcea", "path": "/resourcea/_search", "primary_keys": [], "records_path": "$.hits.hits[*]"},{"name": "resourceb", "path": "/resourceb/_search", "primary_keys": [], "records_path": "$.hits.hits[*]"}]'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ There are many forms of Authentication supported by this tap. By default for leg
 - API Key
 - Bearer Token
 - OAuth
+- AWS
 
 Please note that OAuthJWTAuthentication has not been developed. If you are interested in contributing this, please fork and make a pull request. 
 
@@ -201,7 +202,7 @@ will overwrite their top-level counterparts except where noted below:
   might be **meta_lastUpdated**. The replication_key is set to meta_lastUpdated, and the search_parameter to last-updated. Note: Please set the `replication_key`, `start_date`, `source_search_field`, and `source_search_query` parameters all together.
 - `source_search_query`: optional: used by the **offset**, **page**, and **hateoas_body** response style. This is a query template to be issued against the API. A simple query template example for FHIR API's is **gt$last_run_date**.
 
-  A more complex example against an Opensearch API, **{\"bool\": {\"filter\": [{\"range\": { \"meta.lastUpdated\": { \"gt\": "$last_run_date\" }}}] }}**. Note: Any required double quotes in the query template must be escaped.
+  A more complex example against an Opensearch API, **{\\"bool\\": {\\"filter\\": [{\\"range\\": { \\"meta.lastUpdated\\": { \\"gt\\": \\"$last_run_date\\" }}}] }}**. Note: Any required double quotes in the query template must be escaped.
 
   At run-time, the tap will dynamically change the value **$last_run_date** with either the defined `start_date` parameter or the last bookmark / state value.
   Example: source_search_field=**last-updated**, the 
@@ -520,16 +521,16 @@ Unlike most API requests, the API query is against an API parameter named `query
 
 ```
 # Access AWS objects via the AWS Open/Elastic Search API
-export api_url="https://<endpoint>.<aws region>.<aws service>.amazonaws.com"
-export aws_credentials='{"aws_access_key_id": "<removed aws access key id>", "aws_secret_access_key": "removed aws secret access key>", "aws_region": "<aws region e.g. us‑east‑1>", "aws_service": "<aws service e.g. es for opensearch>", "create_signed_credentials": true}'
-export start_date="2001-01-01T00:00:00.00+12:00"
-export pagination_request_style="jsonpath_paginator"
-export pagination_response_style="offset"
-export use_request_body_not_params=true
-export next_page_token_path='$.hits.hits[-1:].sort'
-export pagination_next_page_param="search_after"
-export auth_method='aws'
-export streams='[{"name": "careplan", "params": {"size": 100, "sort": "_id"}, "path": "/careplan/_search", "primary_keys": [], "records_path": "$.hits.hits[*]", "replication_key": "_source_meta_lastUpdated", "source_search_field": "query", "source_search_query": "{\"bool\": {\"filter\": [{\"range\": { \"meta.lastUpdated\": { \"gt\": \"$last_run_date\" }}}] }}"}]'
+export TAP_REST_API_MSDK_API_URL="https://<endpoint>.<aws region>.<aws service>.amazonaws.com"
+export TAP_REST_API_MSDK_AWS_CREDENTIALS='{"aws_access_key_id": "<removed aws access key id>", "aws_secret_access_key": "removed aws secret access key>", "aws_region": "<aws region e.g. us‑east‑1>", "aws_service": "<aws service e.g. es for opensearch>", "create_signed_credentials": true}'
+export TAP_REST_API_MSDK_START_DATE="2001-01-01T00:00:00.00+12:00"
+export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="jsonpath_paginator"
+export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="offset"
+export TAP_REST_API_MSDK_USE_REQUEST_BODY_NOT_PARAMS=true
+export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.hits.hits[-1:].sort'
+export TAP_REST_API_MSDK_PAGINATION_NEXT_PAGE_PARAM="search_after"
+export TAP_REST_API_MSDK_AUTH_METHOD='aws'
+export TAP_REST_API_MSDK_STREAMS='[{"name": "careplan", "params": {"size": 100, "sort": "_id"}, "path": "/careplan/_search", "primary_keys": [], "records_path": "$.hits.hits[*]", "replication_key": "_source_meta_lastUpdated", "source_search_field": "query", "source_search_query": "{\"bool\": {\"filter\": [{\"range\": { \"meta.lastUpdated\": { \"gt\": \"$last_run_date\" }}}] }}"}]'
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ plugins:
           kind: string
         - name: pagination_limit_per_page_param
           kind: string
+        - name: pagination_total_limit_param
+          kind: string
         - name: streams
           kind: array
         - name: name
@@ -134,6 +136,7 @@ provided at the top-level will be the default values for each stream.:
 - `pagination_results_limit`: optional: limits the max number of records. Note: Will cause an exception if the limit is hit (except for the `restapi_header_link_paginator`). This should be used for development purposes to restrict the total number of records returned by the API. Defaults to None.
 - `pagination_next_page_param`: optional: The name of the param that indicates the page/offset. Defaults to None.
 - `pagination_limit_per_page_param`: optional: The name of the param that indicates the limit/per_page. Defaults to None.
+- `pagination_total_limit_param`: optional: The name of the param that indicates the total limit e.g. total, count. Defaults to total
 - `next_page_token_path`: optional: a jsonpath string representing the path to the "next page" token. Defaults to `'$.next_page'` for the `jsonpath_paginator` paginator only otherwise None.
 - `streams`: required: a list of objects that contain the configuration of each stream. See stream-level params below.
 - `path`: optional: see stream-level params below.
@@ -273,6 +276,7 @@ There are additional request styles supported as follows for pagination.
   - `offset` is calculated from the previous response, or not set if there is no previous response
   - `pagination_page_size` - Sets a limit to number of records per page / response. Default `25` records.
   - `pagination_limit_per_page_param` - the name of the API parameter to limit number of records per page. Default parameter name `limit`.
+  - `pagination_total_limit_param` - The name of the param that indicates the total limit e.g. total, count. Defaults to total
   - `next_page_token_path` - Used to locate an appropriate link in the response. Default None - but looks in the `pagination` section of the JSON response by default. Example, jsonpath to get the offset from the NOAA API `'$.metadata.resultset'`.
 - `simple_header_paginator` - This style uses links in the Header Response to locate the next page. Example the `x-next-page` link used by the Gitlab API.
 - `header_link_paginator` - This style uses the default header link paginator from the Meltano SDK.
@@ -456,6 +460,7 @@ export TAP_REST_API_MSDK_HEADERS='{"token": "<enter NOAA token>"}'
 export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.metadata.resultset'
 export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="offset_paginator"
 export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="style1"
+export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "locationcategories", "params": {"limit": "5"}, "path": "/locationcategories", "primary_keys": ["id"], "records_path": "$.results[*]"}]'
 ```
 

--- a/README.md
+++ b/README.md
@@ -464,6 +464,22 @@ export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="count"
 export TAP_REST_API_MSDK_STREAMS='[{"name": "locationcategories", "params": {"limit": "5"}, "path": "/locationcategories", "primary_keys": ["id"], "records_path": "$.results[*]"}]'
 ```
 
+### DBT API Example
+
+This example uses the `offset paginator` to access the DBT API to return location categories. In this example the offset tokens are not in the default location of `pagination` so the `next_page_token_path` is set to the DBT API offset location in the json response i.e. `'$.metadata.resultset'`. This example also sets a limit parameter in the `streams` to only return 5 records at a time to prove the pagination is working.
+
+```
+# Access Locations Categories objects via the DBT Cloud API
+# Access Gitlab objects via the DBT Cloud API
+export TAP_REST_API_MSDK_API_URL=https://<removed your url>.getdbt.com/api/v2/accounts/<removed account id>
+export TAP_REST_API_MSDK_HEADERS='{"Authorization": "Bearer <removed place in bearer token>"}'
+export TAP_REST_API_MSDK_NEXT_PAGE_TOKEN_PATH='$.extra'
+export TAP_REST_API_MSDK_PAGINATION_REQUEST_STYLE="offset_paginator"
+export TAP_REST_API_MSDK_PAGINATION_RESPONSE_STYLE="style1"
+export TAP_REST_API_MSDK_PAGINATION_TOTAL_LIMIT_PARAM="total_count"
+export TAP_REST_API_MSDK_STREAMS='[{"name": "jobs", "path": "/jobs", "primary_keys": ["id"], "records_path": "$.data[*]"}]'
+```
+
 ## Usage
 
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,5 @@
 {
-    "pagination_request_style": "hateoas_body",
+    "pagination_request_style": "jsonpath_paginator",
     "pagination_response_style": "hateoas_body",
     "api_url": "https://myexample_fhir_api_url/base_folder",
     "pagination_page_size": 100,

--- a/config.sample.json
+++ b/config.sample.json
@@ -20,8 +20,8 @@
             "records_path": "$.entry[*].resource",
             "replication_key": "meta_lastUpdated",
             "start_date": "2001-01-01T00:00:00.00+12:00",            
-            "search_parameter": "last-updated",
-            "search_prefix": "gt"
+            "source_search_field": "last-updated",
+            "source_search_query": "gt$last_run_date"
         }
     ]
 }

--- a/meltano.yml
+++ b/meltano.yml
@@ -20,6 +20,12 @@ plugins:
           kind: string
         - name: pagination_page_size
           kind: integer
+        - name: pagination_results_limit
+          kind: integer
+        - name: pagination_next_page_param
+          kind: string
+        - name: pagination_limit_per_page_param
+          kind: string
         - name: streams
           kind: array
         - name: path

--- a/meltano.yml
+++ b/meltano.yml
@@ -18,6 +18,8 @@ plugins:
           kind: string
         - name: pagination_response_style
           kind: string
+        - name: use_request_body_not_params
+          kind: boolean
         - name: pagination_page_size
           kind: integer
         - name: pagination_results_limit
@@ -48,9 +50,9 @@ plugins:
           kind: integer
         - name: start_date
           kind: date_iso8601
-        - name: search_parameter
+        - name: source_search_field
           kind: string
-        - name: search_prefix
+        - name: source_search_query
           kind: string
         - name: auth_method
           kind: string
@@ -80,6 +82,8 @@ plugins:
           kind: object
         - name: oauth_expiration_secs
           kind: integer
+        - name: aws_credentials
+          kind: object
       config:
         api_url: https://earthquake.usgs.gov/fdsnws
         records_path: "$.features[*]"

--- a/meltano.yml
+++ b/meltano.yml
@@ -26,6 +26,8 @@ plugins:
           kind: string
         - name: pagination_limit_per_page_param
           kind: string
+        - name: pagination_total_limit_param
+          kind: string
         - name: streams
           kind: array
         - name: path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ requests = "^2.25.1"
 singer-sdk = "^0.26.0"
 genson = "^1.2.2"
 atomicwrites = "^1.4.0"
+requests-aws4auth = "^1.2.3"
+boto3 = "^1.26.156"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -239,8 +239,8 @@ def select_authenticator(self) -> Any:
             self.http_auth = None
 
         return self.http_auth
-    else:
-        self.logger.error(f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, or bearer_token.")
+    elif auth_method != "no_auth":
+        self.logger.error(f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, bearer_token, or aws.")
         raise ValueError(
-            f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, or bearer_token."
+            f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, bearer_token, or aws."
         )

--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -44,8 +44,8 @@ class AWSConnectClient:
         aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
         aws_region = config.get('aws_region') or os.environ.get('AWS_REGION')
         self.aws_service = config.get('aws_service',None) or os.environ.get('AWS_SERVICE')
-        
-        if not config.get('create_signed_credentials',None):
+
+        if not config.get('create_signed_credentials',True):
             self.create_signed_credentials = False
 
         # AWS credentials based authentication

--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -1,0 +1,249 @@
+"""REST authentication handling."""
+
+import os
+from requests_aws4auth import AWS4Auth
+import boto3
+from singer_sdk.authenticators import APIAuthenticatorBase, SimpleAuthenticator, APIKeyAuthenticator, BasicAuthenticator, BearerTokenAuthenticator, OAuthAuthenticator
+import requests
+
+from singer_sdk.streams import RESTStream
+
+class AWSConnectClient:
+    """A connection class to AWS Resources"""
+
+    def __init__(
+            self,
+            connection_config,
+            create_signed_credentials: bool = True
+        ):
+        self.connection_config = connection_config
+        
+
+        # Initialise the variables
+        self.create_signed_credentials = create_signed_credentials
+        self.aws_auth = None
+        self.region = None
+        self.credentials = None
+        self.aws_service = None
+        
+        # Establish a AWS Client
+        self.credentials = self._create_aws_client()
+        
+        # Store AWS Signed Credentials
+        self._store_aws4auth_credentials()
+
+
+    def _create_aws_client(self, config=None):
+        if not config:
+            config = self.connection_config
+
+        # Get the required parameters from config file and/or environment variables
+        aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
+        aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
+        aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+        aws_region = config.get('aws_region') or os.environ.get('AWS_REGION')
+        self.aws_service = config.get('aws_service',None) or os.environ.get('AWS_SERVICE')
+        
+        if not config.get('create_signed_credentials',None):
+            self.create_signed_credentials = False
+
+        # AWS credentials based authentication
+        if aws_access_key_id and aws_secret_access_key:
+            aws_session = boto3.session.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=aws_region,
+                aws_session_token=aws_session_token
+            )
+        # AWS Profile based authentication
+        elif aws_profile:
+            aws_session = boto3.session.Session(profile_name=aws_profile)
+        else:
+            aws_session = None
+            
+        if aws_session:
+            self.region = aws_session.region_name
+            return aws_session.get_credentials()
+        else:
+            return None
+
+      
+    def _store_aws4auth_credentials(self):
+        """Stores the AWS Signed Credential for the available AWS credentials.
+
+        Returns:
+            The None.
+
+        """
+
+        if self.create_signed_credentials and self.credentials:
+            self.aws_auth = AWS4Auth(self.credentials.access_key, self.credentials.secret_key, self.region, self.aws_service, aws_session=self.credentials.token)
+        else:
+            self.aws_auth = None
+
+      
+    def get_awsauth(self):
+        """Return the AWS Signed Connection for provided credentials.
+
+        Returns:
+            The awsauth object.
+
+        """
+
+        return self.aws_auth
+      
+    def get_aws_session_client(self):
+        """Return the AWS Signed Connection for provided credentials.
+
+        Returns:
+            The an AWS Session Client.
+
+        """
+
+        return aws_session.client(self.aws_service,
+                                  region_name=self.region)
+
+
+class ConfigurableOAuthAuthenticator(OAuthAuthenticator):
+
+    @property
+    def oauth_request_body(self) -> dict:
+        """Build up a list of OAuth2 parameters to use depending
+        on what configuration items have been set and the type of OAuth
+        flow set by the grant_type.
+        """
+
+        # Test where the config is located in self
+        if self.config: # Tap Config
+            my_config = self.config
+        elif self._config: # Stream Config
+            my_config = self._config
+        
+        client_id = my_config.get('client_id')
+        client_secret = my_config.get('client_secret')
+        username = my_config.get('username')
+        password = my_config.get('password')
+        refresh_token = my_config.get('refresh_token')
+        grant_type = my_config.get('grant_type')
+        scope = my_config.get('scope')
+        redirect_uri = my_config.get('redirect_uri')
+        oauth_extras = my_config.get('oauth_extras')
+
+        oauth_params = {}
+
+        # Test mandatory parameters based on grant_type
+        if grant_type:
+            oauth_params['grant_type'] = grant_type
+        else:
+            raise ValueError("Missing grant type for OAuth Token.")
+
+        if grant_type == 'client_credentials':
+            if not (client_id and client_secret):
+                raise ValueError(
+                    "Missing either client_id or client_secret for 'client_credentials' grant_type."
+                )
+
+        if grant_type == 'password':
+            if not (username and password):
+                raise ValueError("Missing either username or password for 'password' grant_type.")
+
+        if grant_type == 'refresh_token':
+            if not refresh_token:
+                raise ValueError("Missing either refresh_token for 'refresh_token' grant_type.")
+
+        # Add parameters if they are set
+        if scope:
+            oauth_params['scope'] = scope
+        if client_id:
+            oauth_params['client_id'] = client_id
+        if client_secret:
+            oauth_params['client_secret'] = client_secret
+        if username:
+            oauth_params['username'] = username
+        if password:
+            oauth_params['password'] = password
+        if refresh_token:
+            oauth_params['refresh_token'] = refresh_token
+        if redirect_uri:
+            oauth_params['redirect_uri'] = redirect_uri
+        if oauth_extras:
+            for k, v in oauth_extras.items():
+                oauth_params[k] = v
+
+        return oauth_params
+
+
+def select_authenticator(self) -> APIAuthenticatorBase:
+    """Calls an appropriate SDK Authentication method based on the the set auth_method.
+    If an auth_method is not provided, the tap will call the API using any settings from
+    the headers and params config.
+    Note: Each auth method requires certain configuration to be present see README.md
+    for each auth methods configuration requirements.
+
+    Raises:
+        ValueError: if the auth_method is unknown.
+
+    Returns:
+        A SDK Authenticator or None if no auth_method supplied.
+    """
+    
+    # Test where the config is located in self
+    if self.config: # Tap Config
+        my_config = self.config
+    elif self._config: # Stream Config
+        my_config = self._config
+
+    auth_method = my_config.get('auth_method', "")
+    api_keys = my_config.get('api_keys', '')
+    self.http_auth = None
+
+    # Using API Key Authenticator, keys are extracted from api_keys dict
+    if auth_method == "api_key":
+        if api_keys:
+            for k, v in api_keys.items():
+                key = k
+                value = v
+        return APIKeyAuthenticator(
+            stream=self,
+            key=key,
+            value=value
+        )
+    # Using Basic Authenticator
+    elif auth_method == "basic":
+        return BasicAuthenticator(
+            stream=self,
+            username=my_config.get('username', ''),
+            password=my_config.get('password', '')
+        )
+    # Using OAuth Authenticator
+    elif auth_method == "oauth":
+        return ConfigurableOAuthAuthenticator(
+            stream=self,
+            auth_endpoint=my_config.get('access_token_url', ''),
+            oauth_scopes=my_config.get('scope', ''),
+            default_expiration=my_config.get('oauth_expiration_secs', ''),
+        )
+    # Using Bearer Token Authenticator
+    elif auth_method == "bearer_token":
+        return BearerTokenAuthenticator(
+            stream=self,
+            token=my_config.get('bearer_token', ''),
+        )
+    # Using AWS Authenticator
+    elif auth_method == "aws":
+      
+          # Establish an AWS Connection Client and returned Signed Credentials
+        self.aws_connection = AWSConnectClient(connection_config=my_config.get("aws_credentials",None))
+        
+        if self.aws_connection.aws_auth:
+            self.http_auth = self.aws_connection.aws_auth
+        else:
+            self.http_auth = None
+
+        return self.http_auth
+    else:
+        self.logger.error(f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, or bearer_token.")
+        raise ValueError(
+            f"Unknown authentication method {auth_method}. Use api_key, basic, oauth, or bearer_token."
+        )

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -1,12 +1,11 @@
 """REST client handling, including RestApiStream base class."""
 
 from pathlib import Path
-from typing import Any, Optional
-from singer_sdk.authenticators import APIAuthenticatorBase, SimpleAuthenticator
-from tap_rest_api_msdk.auth import select_authenticator
-import requests
+from typing import Any
 
+from singer_sdk.authenticators import APIAuthenticatorBase
 from singer_sdk.streams import RESTStream
+from tap_rest_api_msdk.auth import select_authenticator
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
@@ -29,7 +28,7 @@ class RestApiStream(RESTStream):
       
 
     @property
-    def authenticator(self) -> APIAuthenticatorBase:
+    def authenticator(self) -> Any:
         """Calls an appropriate SDK Authentication method based on the the set auth_method
         which is set in the config.
         If an authenticator (auth_method) is not specified, REST-based taps will simply pass
@@ -42,7 +41,7 @@ class RestApiStream(RESTStream):
             ValueError: if the auth_method is unknown.
 
         Returns:
-            A SDK Authenticator or SimpleAuthenticator if no auth_method supplied.
+            A SDK Authenticator or APIAuthenticatorBase if no auth_method supplied.
         """
 
         stream_authenticator = select_authenticator(self)
@@ -50,6 +49,6 @@ class RestApiStream(RESTStream):
         if stream_authenticator:
             return stream_authenticator
         else:
-            return SimpleAuthenticator(stream=self)
+            return APIAuthenticatorBase(stream=self)
           
 

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+from memoization import cached
 from singer_sdk.authenticators import APIAuthenticatorBase
 from singer_sdk.streams import RESTStream
 from tap_rest_api_msdk.auth import select_authenticator
@@ -28,14 +29,19 @@ class RestApiStream(RESTStream):
       
 
     @property
+    @cached
     def authenticator(self) -> Any:
         """Calls an appropriate SDK Authentication method based on the the set auth_method
-        which is set in the config.
+        which is set via the config.
         If an authenticator (auth_method) is not specified, REST-based taps will simply pass
-        `http_headers` as defined in the stream class.
+        `http_headers` as defined in the tap and stream classes.
         
-        Note: Each auth method requires certain configuration to be present see README.md
+        Note 1: Each auth method requires certain configuration to be present see README.md
         for each auth methods configuration requirements.
+        
+        Note 2: The cached decorator will have all calls to the authenticator use the
+        same instance logic to speed up processing. TODO: Examine if this affects OAuth2
+        callbacks and if logic is required for callback for expiring AWS STS tokens.
 
         Raises:
             ValueError: if the auth_method is unknown.

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -1,5 +1,8 @@
 """REST client handling, including RestApiStream base class."""
 
+import os
+from requests_aws4auth import AWS4Auth
+import boto3
 from pathlib import Path
 from typing import Any
 
@@ -20,3 +23,99 @@ class RestApiStream(RESTStream):
 
         """
         return self.config["api_url"]
+
+class AWSConnectClient:
+    """A connection class to AWS Resources"""
+
+    def __init__(
+            self,
+            connection_config,
+            create_signed_credentials: bool = True
+        ):
+        self.connection_config = connection_config
+        
+
+        # Initialise the variables
+        self.create_signed_credentials = create_signed_credentials
+        self.aws_auth = None
+        self.region = None
+        self.credentials = None
+        self.aws_service = None
+        
+        # Establish a AWS Client
+        self.credentials = self._create_aws_client()
+        
+        # Store AWS Signed Credentials
+        self._store_aws4auth_credentials()
+
+
+    def _create_aws_client(self, config=None):
+        if not config:
+            config = self.connection_config
+
+        # Get the required parameters from config file and/or environment variables
+        aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
+        aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
+        aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
+        aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
+        aws_region = config.get('aws_region') or os.environ.get('AWS_REGION')
+        self.aws_service = config.get('aws_service',None) or os.environ.get('AWS_SERVICE')
+        
+        if not config.get('create_signed_credentials',None):
+            self.create_signed_credentials = False
+
+        # AWS credentials based authentication
+        if aws_access_key_id and aws_secret_access_key:
+            aws_session = boto3.session.Session(
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                region_name=aws_region,
+                aws_session_token=aws_session_token
+            )
+        # AWS Profile based authentication
+        elif aws_profile:
+            aws_session = boto3.session.Session(profile_name=aws_profile)
+        else:
+            aws_session = None
+            
+        if aws_session:
+            self.region = aws_session.region_name
+            return aws_session.get_credentials()
+        else:
+            return None
+
+      
+    def _store_aws4auth_credentials(self):
+        """Stores the AWS Signed Credential for the available AWS credentials.
+
+        Returns:
+            The None.
+
+        """
+
+        if self.create_signed_credentials and self.credentials:
+            self.aws_auth = AWS4Auth(self.credentials.access_key, self.credentials.secret_key, self.region, self.aws_service, aws_session=self.credentials.token)
+        else:
+            self.aws_auth = None
+
+      
+    def get_awsauth(self):
+        """Return the AWS Signed Connection for provided credentials.
+
+        Returns:
+            The awsauth object.
+
+        """
+
+        return self.aws_auth
+      
+    def get_aws_session_client(self):
+        """Return the AWS Signed Connection for provided credentials.
+
+        Returns:
+            The an AWS Session Client.
+
+        """
+
+        return aws_session.client(self.aws_service,
+                                  region_name=self.region)

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -5,10 +5,32 @@ from requests_aws4auth import AWS4Auth
 import boto3
 from pathlib import Path
 from typing import Any
+from singer_sdk.authenticators import APIAuthenticatorBase
+import requests
 
 from singer_sdk.streams import RESTStream
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
+
+class AWSAuthenticator(APIAuthenticatorBase):
+  
+    def __init__(
+        self,
+        stream: RESTStream,
+        http_auth = None,
+    ) -> None:
+        """Create a new AWSAuthenticator extending the APIAuthenticatorBase.
+
+        If auths is provided, it will be added to the PreparedRequest
+        for the stream.
+
+        Args:
+            stream: The stream instance to use with this authenticator.
+            auth: AWS4Auth object.
+        """
+        super().__init__(stream=stream)
+
+        # TODO: Add logic to set stream.http_auth
 
 
 class RestApiStream(RESTStream):

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -1,40 +1,21 @@
 """REST client handling, including RestApiStream base class."""
 
-import os
-from requests_aws4auth import AWS4Auth
-import boto3
 from pathlib import Path
-from typing import Any
-from singer_sdk.authenticators import APIAuthenticatorBase
+from typing import Any, Optional
+from singer_sdk.authenticators import APIAuthenticatorBase, SimpleAuthenticator
+from tap_rest_api_msdk.auth import select_authenticator
 import requests
 
 from singer_sdk.streams import RESTStream
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
-class AWSAuthenticator(APIAuthenticatorBase):
-  
-    def __init__(
-        self,
-        stream: RESTStream,
-        http_auth = None,
-    ) -> None:
-        """Create a new AWSAuthenticator extending the APIAuthenticatorBase.
-
-        If auths is provided, it will be added to the PreparedRequest
-        for the stream.
-
-        Args:
-            stream: The stream instance to use with this authenticator.
-            auth: AWS4Auth object.
-        """
-        super().__init__(stream=stream)
-
-        # TODO: Add logic to set stream.http_auth
-
 
 class RestApiStream(RESTStream):
     """rest-api stream class."""
+
+    # Intialise self.http_auth used by prepare_request
+    http_auth = None
 
     @property
     def url_base(self) -> Any:
@@ -45,99 +26,30 @@ class RestApiStream(RESTStream):
 
         """
         return self.config["api_url"]
-
-class AWSConnectClient:
-    """A connection class to AWS Resources"""
-
-    def __init__(
-            self,
-            connection_config,
-            create_signed_credentials: bool = True
-        ):
-        self.connection_config = connection_config
-        
-
-        # Initialise the variables
-        self.create_signed_credentials = create_signed_credentials
-        self.aws_auth = None
-        self.region = None
-        self.credentials = None
-        self.aws_service = None
-        
-        # Establish a AWS Client
-        self.credentials = self._create_aws_client()
-        
-        # Store AWS Signed Credentials
-        self._store_aws4auth_credentials()
-
-
-    def _create_aws_client(self, config=None):
-        if not config:
-            config = self.connection_config
-
-        # Get the required parameters from config file and/or environment variables
-        aws_profile = config.get('aws_profile') or os.environ.get('AWS_PROFILE')
-        aws_access_key_id = config.get('aws_access_key_id') or os.environ.get('AWS_ACCESS_KEY_ID')
-        aws_secret_access_key = config.get('aws_secret_access_key') or os.environ.get('AWS_SECRET_ACCESS_KEY')
-        aws_session_token = config.get('aws_session_token') or os.environ.get('AWS_SESSION_TOKEN')
-        aws_region = config.get('aws_region') or os.environ.get('AWS_REGION')
-        self.aws_service = config.get('aws_service',None) or os.environ.get('AWS_SERVICE')
-        
-        if not config.get('create_signed_credentials',None):
-            self.create_signed_credentials = False
-
-        # AWS credentials based authentication
-        if aws_access_key_id and aws_secret_access_key:
-            aws_session = boto3.session.Session(
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                region_name=aws_region,
-                aws_session_token=aws_session_token
-            )
-        # AWS Profile based authentication
-        elif aws_profile:
-            aws_session = boto3.session.Session(profile_name=aws_profile)
-        else:
-            aws_session = None
-            
-        if aws_session:
-            self.region = aws_session.region_name
-            return aws_session.get_credentials()
-        else:
-            return None
-
       
-    def _store_aws4auth_credentials(self):
-        """Stores the AWS Signed Credential for the available AWS credentials.
+
+    @property
+    def authenticator(self) -> APIAuthenticatorBase:
+        """Calls an appropriate SDK Authentication method based on the the set auth_method
+        which is set in the config.
+        If an authenticator (auth_method) is not specified, REST-based taps will simply pass
+        `http_headers` as defined in the stream class.
+        
+        Note: Each auth method requires certain configuration to be present see README.md
+        for each auth methods configuration requirements.
+
+        Raises:
+            ValueError: if the auth_method is unknown.
 
         Returns:
-            The None.
-
+            A SDK Authenticator or SimpleAuthenticator if no auth_method supplied.
         """
 
-        if self.create_signed_credentials and self.credentials:
-            self.aws_auth = AWS4Auth(self.credentials.access_key, self.credentials.secret_key, self.region, self.aws_service, aws_session=self.credentials.token)
+        stream_authenticator = select_authenticator(self)
+        
+        if stream_authenticator:
+            return stream_authenticator
         else:
-            self.aws_auth = None
+            return SimpleAuthenticator(stream=self)
+          
 
-      
-    def get_awsauth(self):
-        """Return the AWS Signed Connection for provided credentials.
-
-        Returns:
-            The awsauth object.
-
-        """
-
-        return self.aws_auth
-      
-    def get_aws_session_client(self):
-        """Return the AWS Signed Connection for provided credentials.
-
-        Returns:
-            The an AWS Session Client.
-
-        """
-
-        return aws_session.client(self.aws_service,
-                                  region_name=self.region)

--- a/tap_rest_api_msdk/pagination.py
+++ b/tap_rest_api_msdk/pagination.py
@@ -6,7 +6,7 @@ import requests
 from dateutil.parser import parse
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import BaseOffsetPaginator, HeaderLinkPaginator, BasePageNumberPaginator
-from utils import unnest_dict
+from tap_rest_api_msdk.utils import unnest_dict
 
 class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
     def __init__(

--- a/tap_rest_api_msdk/pagination.py
+++ b/tap_rest_api_msdk/pagination.py
@@ -1,8 +1,12 @@
-#from singer_sdk.pagination import HeaderLinkPaginator, BaseOffsetPaginator, BasePageNumberPaginator
-from typing import Any, Optional
+"""REST API pagination handling."""
+from typing import Any, Optional, cast
+from urllib.parse import urlparse, parse_qs
 
 import requests
-from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
+from dateutil.parser import parse
+from singer_sdk.helpers.jsonpath import extract_jsonpath
+from singer_sdk.pagination import BaseOffsetPaginator, HeaderLinkPaginator, BasePageNumberPaginator
+from utils import unnest_dict
 
 class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
     def __init__(

--- a/tap_rest_api_msdk/pagination.py
+++ b/tap_rest_api_msdk/pagination.py
@@ -1,0 +1,177 @@
+#from singer_sdk.pagination import HeaderLinkPaginator, BaseOffsetPaginator, BasePageNumberPaginator
+from typing import Any, Optional
+
+import requests
+from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
+
+class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._jsonpath = jsonpath
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to `hasMore` in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self._jsonpath:
+            return next(extract_jsonpath(self._jsonpath, response.json()), None)
+        else:
+            return response.json().get("hasMore", None)
+
+class RestAPIOffsetPaginator(BaseOffsetPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        pagination_total_limit_param: str,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.jsonpath = jsonpath
+        self.pagination_total_limit_param = pagination_total_limit_param
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to pagination in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self.jsonpath:
+            pagination = next(extract_jsonpath(self.jsonpath, response.json()), None)
+        else:
+            pagination = response.json().get("pagination", None)
+        if pagination:
+            pagination = unnest_dict(pagination)
+
+        if pagination and all(x in pagination for x in ["offset", "limit"]):
+            record_limit = pagination.get(self.pagination_total_limit_param,0)
+            records_read = pagination["offset"] + pagination["limit"]
+            if records_read <= record_limit:
+                return True
+
+        return False
+
+class RestAPIHeaderLinkPaginator(HeaderLinkPaginator):
+    def __init__(
+        self,
+        *args,
+        pagination_page_size: int = 25,
+        pagination_results_limit: Optional[int] = None,
+        use_fake_since_parameter: Optional[bool] = False,
+        replication_key: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.pagination_page_size = pagination_page_size
+        self.pagination_results_limit = pagination_results_limit
+        self.use_fake_since_parameter = use_fake_since_parameter
+        self.replication_key = replication_key
+
+    def get_next_url(
+        self, response: requests.Response
+    ) -> Optional[Any]:
+        """Return next page parameter(s) for identifying the next page
+           or None if no more pages.
+           
+           Logic based on https://github.com/MeltanoLabs/tap-github
+           
+        Args:
+            response: The most recent response object.
+            pagination_page_size: A limit for records per page. Default=25
+            pagination_results_limit: A limit to the number of pages returned
+            use_fake_since_parameter: A work around for GitHub. default=False
+            replication_key: Key for incremental processing
+
+        Returns:
+            Page Parameters if there are more pages to fetch, else None.
+        """
+        # Exit if the set Record Limit is reached.
+        if (
+            self._page_count
+            and self.pagination_results_limit
+            and (
+                cast(int, self._page_count) * self.pagination_page_size >= self.pagination_results_limit
+            )
+        ):
+            return None
+          
+        # Leverage header links returned by the GitHub API.
+        if "next" not in response.links.keys():
+            return None
+
+        # Exit early if there is no URL in the next links
+        if not response.links.get("next",{}).get("url"):
+            return None
+
+        resp_json = response.json()
+        if isinstance(resp_json, list):
+            results = resp_json
+        else:
+            results = resp_json.get("items")
+
+        # Exit early if the response has no items. ? Maybe duplicative the "next" link check.
+        if not results:
+            return None
+          
+        # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
+        # the "since" parameter out of the box. So we use a workaround here to exit early.
+        # For such streams, we sort by descending dates (most recent first), and paginate
+        # "back in time" until we reach records before our "fake_since" parameter.
+        if self.replication_key and self.use_fake_since_parameter:
+            request_parameters = parse_qs(str(urlparse(response.request.url).query))
+            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
+            try:
+                since = (
+                    request_parameters["fake_since"][0].replace(" ", "+")
+                    if "fake_since" in request_parameters
+                    else ""
+                )
+            except IndexError:
+                return None
+
+            direction = (
+                request_parameters["direction"][0]
+                if "direction" in request_parameters
+                else None
+            )
+
+            # commit_timestamp is a constructed key which does not exist in the raw response
+            replication_date = (
+                results[-1][self.replication_key]
+                if self.replication_key != "commit_timestamp"
+                else results[-1]["commit"]["committer"]["date"]
+            )
+            # exit early if the replication_date is before our since parameter
+            if (
+                since
+                and direction == "desc"
+                and (parse(replication_date) < parse(since))
+            ):
+                return None
+
+        # Use header links returned by the API to return the query parameters.
+        parsed_url = urlparse(response.links["next"]["url"])
+
+        if parsed_url.query:
+            return(parsed_url.query)
+          
+        return None

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -1,18 +1,19 @@
 """Stream type classes for tap-rest-api-msdk."""
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Optional, cast
+from typing import Any, Dict, Iterable, Optional
 
-import requests
 import email.utils
+import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
-from tap_rest_api_msdk.pagination import SinglePagePaginator, BaseHATEOASPaginator, JSONPathPaginator, SimpleHeaderPaginator, RestAPIHeaderLinkPaginator, RestAPIOffsetPaginator, RestAPIBasePageNumberPaginator
-from tap_rest_api_msdk.client import RestApiStream
-from tap_rest_api_msdk.utils import flatten_json, unnest_dict
+from singer_sdk.pagination import SinglePagePaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator
 from urllib.parse import urlparse, parse_qsl, parse_qs
+from tap_rest_api_msdk.client import RestApiStream
+from tap_rest_api_msdk.pagination import RestAPIHeaderLinkPaginator, RestAPIOffsetPaginator, RestAPIBasePageNumberPaginator
+from tap_rest_api_msdk.utils import flatten_json
 
-import logging
-import http.client
+#import logging
+#import http.client
 
 # Remove commented section to show http_request for debugging
 #http.client.HTTPConnection.debuglevel = 1
@@ -374,7 +375,7 @@ class DynamicStream(RestApiStream):
                 
         # Set Pagination Limits if required.
         if self.pagination_page_size and self.pagination_limit_per_page_param:
-            params[pagination_limit_per_page_param] = self.pagination_page_size
+            params[self.pagination_limit_per_page_param] = self.pagination_page_size
                 
         if next_page_token:
             # Parse the next_page_token for the path and parameters

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -8,7 +8,7 @@ import email.utils
 from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from tap_rest_api_msdk.client import RestApiStream
-from tap_rest_api_msdk.utils import flatten_json, compress_dict
+from tap_rest_api_msdk.utils import flatten_json, unnest_dict
 from urllib.parse import urlparse, parse_qsl, parse_qs
 
 
@@ -68,7 +68,7 @@ class RestAPIOffsetPaginator(BaseOffsetPaginator):
         else:
             pagination = response.json().get("pagination", None)
         if pagination:
-            pagination = compress_dict(pagination)
+            pagination = unnest_dict(pagination)
 
         if pagination and all(x in pagination for x in ["offset", "limit"]):
             record_limit = pagination.get(self.pagination_total_limit_param,0)

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -1,13 +1,184 @@
 """Stream type classes for tap-rest-api-msdk."""
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, cast
 
 import requests
+import email.utils
+from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from tap_rest_api_msdk.client import RestApiStream
 from tap_rest_api_msdk.utils import flatten_json
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import urlparse, parse_qsl, parse_qs
+
+
+class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._jsonpath = jsonpath
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to `hasMore` in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self._jsonpath:
+            return next(extract_jsonpath(self._jsonpath, response.json()), None)
+        else:
+            return response.json().get("hasMore", None)
+
+class RestAPIOffsetPaginator(BaseOffsetPaginator):
+    def __init__(
+        self,
+        *args,
+        jsonpath: str = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._jsonpath = jsonpath
+
+    def has_more(self, response: requests.Response):
+        """Return True if there are more pages to fetch.
+
+        Args:
+            response: The most recent response object.
+            jsonpath: An optional jsonpath to where the tokens are located in
+                      the response, defaults to pagination in the response.
+
+        Returns:
+            Whether there are more pages to fetch.
+        """
+        
+        if self._jsonpath:
+            pagination = next(extract_jsonpath(self._jsonpath, response.json()), None)
+        else:
+            pagination = response.json().get("pagination", None)
+
+        if pagination and all(x in pagination for x in ["offset", "limit"]):
+            record_limit = pagination.get("total",pagination.get("count",0))
+            records_read = pagination["offset"] + pagination["limit"]
+            if records_read <= record_limit:
+                return True
+
+        return False
+
+class RestAPIHeaderLinkPaginator(HeaderLinkPaginator):
+    def __init__(
+        self,
+        *args,
+        pagination_page_size: int = 25,
+        pagination_results_limit: Optional[int] = None,
+        use_fake_since_parameter: Optional[bool] = False,
+        replication_key: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.pagination_page_size = pagination_page_size
+        self.pagination_results_limit = pagination_results_limit
+        self.use_fake_since_parameter = use_fake_since_parameter
+        self.replication_key = replication_key
+
+    def get_next_url(
+        self, response: requests.Response
+    ) -> Optional[Any]:
+        """Return next page parameter(s) for identifying the next page
+           or None if no more pages.
+           
+           Logic based on https://github.com/MeltanoLabs/tap-github
+           
+        Args:
+            response: The most recent response object.
+            pagination_page_size: A limit for records per page. Default=25
+            pagination_results_limit: A limit to the number of pages returned
+            use_fake_since_parameter: A work around for GitHub. default=False
+            replication_key: Key for incremental processing
+
+        Returns:
+            Page Parameters if there are more pages to fetch, else None.
+        """
+        # Exit if the set Record Limit is reached.
+        if (
+            self._page_count
+            and self.pagination_results_limit
+            and (
+                cast(int, self._page_count) * self.pagination_page_size >= self.pagination_results_limit
+            )
+        ):
+            return None
+          
+        # Leverage header links returned by the GitHub API.
+        if "next" not in response.links.keys():
+            return None
+
+        # Exit early if there is no URL in the next links
+        if not response.links.get("next",{}).get("url"):
+            return None
+
+        resp_json = response.json()
+        if isinstance(resp_json, list):
+            results = resp_json
+        else:
+            results = resp_json.get("items")
+
+        # Exit early if the response has no items. ? Maybe duplicative the "next" link check.
+        if not results:
+            return None
+          
+        # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
+        # the "since" parameter out of the box. So we use a workaround here to exit early.
+        # For such streams, we sort by descending dates (most recent first), and paginate
+        # "back in time" until we reach records before our "fake_since" parameter.
+        if self.replication_key and self.use_fake_since_parameter:
+            request_parameters = parse_qs(str(urlparse(response.request.url).query))
+            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
+            try:
+                since = (
+                    request_parameters["fake_since"][0].replace(" ", "+")
+                    if "fake_since" in request_parameters
+                    else ""
+                )
+            except IndexError:
+                return None
+
+            direction = (
+                request_parameters["direction"][0]
+                if "direction" in request_parameters
+                else None
+            )
+
+            # commit_timestamp is a constructed key which does not exist in the raw response
+            replication_date = (
+                results[-1][self.replication_key]
+                if self.replication_key != "commit_timestamp"
+                else results[-1]["commit"]["committer"]["date"]
+            )
+            # exit early if the replication_date is before our since parameter
+            if (
+                since
+                and direction == "desc"
+                and (parse(replication_date) < parse(since))
+            ):
+                return None
+
+        # Use header links returned by the API to return the query parameters.
+        parsed_url = urlparse(response.links["next"]["url"])
+
+        if parsed_url.query:
+            return(parsed_url.query)
+          
+        return None
 
 
 class DynamicStream(RestApiStream):
@@ -29,6 +200,9 @@ class DynamicStream(RestApiStream):
         pagination_request_style: str = "default",
         pagination_response_style: str = "default",
         pagination_page_size: Optional[int] = None,
+        pagination_results_limit: Optional[int] = None,
+        pagination_next_page_param: Optional[str] = None,
+        pagination_limit_per_page_param: Optional[str] = None,
         start_date: Optional[datetime] = None,
         search_parameter: Optional[str] = None,
         search_prefix: Optional[str] = None,
@@ -50,6 +224,9 @@ class DynamicStream(RestApiStream):
             pagination_request_style: see tap.py
             pagination_response_style: see tap.py
             pagination_page_size: see tap.py
+            pagination_results_limit: see tap.py
+            pagination_next_page_param: see tap.py
+            pagination_limit_per_page_param: see tap.py
             start_date: see tap.py
             search_parameter: see tap.py
             search_prefix: see tap.py
@@ -68,23 +245,57 @@ class DynamicStream(RestApiStream):
         self.replication_key = replication_key
         self.except_keys = except_keys
         self.records_path = records_path
-        self.next_page_token_jsonpath = (
-            next_page_token_path  # Or override `get_next_page_token`.
-        )
-        self.pagination_page_size = pagination_page_size
-        get_url_params_styles = {"style1": self._get_url_params_style1,
+        if next_page_token_path:
+            self.next_page_token_jsonpath = next_page_token_path
+        elif pagination_request_style == 'jsonpath_paginator' or pagination_request_style == 'default':
+            self.next_page_token_jsonpath = "$.next_page" # Set default for jsonpath_paginator
+        get_url_params_styles = {"style1": self._get_url_params_offset_style,
+                                 "offset": self._get_url_params_offset_style,
+                                 "page": self._get_url_params_page_style,
+                                 "header_link": self._get_url_params_header_link,
                                  "hateoas_body": self._get_url_params_hateoas_body}
         self.get_url_params = get_url_params_styles.get(  # type: ignore
-            pagination_response_style, self._get_url_params_default
-        )
-        get_next_page_token_styles = {"style1": self._get_next_page_token_style1,
-                                      "hateoas_body": self._get_next_page_token_hateoas_body}
-        self.get_next_page_token = get_next_page_token_styles.get(  # type: ignore
-            pagination_response_style, self._get_next_page_token_default
-        )
+            pagination_response_style, self._get_url_params_page_style
+        ) # Defaults to page_style url_params
+        self.pagination_request_style = pagination_request_style
+        self.pagination_results_limit = pagination_results_limit
+        self.pagination_next_page_param = pagination_next_page_param
+        self.pagination_limit_per_page_param = pagination_limit_per_page_param
         self.start_date = start_date
         self.search_parameter = search_parameter
         self.search_prefix = search_prefix
+        
+        # Setting Pagination Limits
+        if self.pagination_request_style == 'restapi_header_link_paginator':
+            if pagination_page_size:
+                self.pagination_page_size = pagination_page_size
+            else:
+                if self.pagination_limit_per_page_param:
+                    page_limit_param = self.pagination_limit_per_page_param
+                else:
+                    page_limit_param = "per_page"
+                self.pagination_page_size = int(self.params.get(page_limit_param, 25)) # Default to requesting 25 records
+        elif self.pagination_request_style == 'style1' or self.pagination_request_style == 'offset_paginator':
+            if self.pagination_results_limit:
+                self.ABORT_AT_RECORD_COUNT = self.pagination_results_limit # Will raise an exception.
+            if pagination_page_size:
+                self.pagination_page_size = pagination_page_size
+            else:
+                if self.pagination_limit_per_page_param:
+                    page_limit_param = self.pagination_limit_per_page_param
+                else:
+                    page_limit_param = "limit"
+                self.pagination_page_size = int(self.params.get(page_limit_param, 25)) # Default to requesting 25 records
+        else:
+            if self.pagination_results_limit:
+                self.ABORT_AT_RECORD_COUNT = self.pagination_results_limit # Will raise an exception.
+            self.pagination_page_size = pagination_page_size
+
+        # GitHub is missing the "since" parameter on a few endpoints
+        # set this parameter to True if your stream needs to navigate data in descending order
+        # and try to exit early on its own.
+        # This only has effect on streams whose `replication_key` is `updated_at`.
+        self.use_fake_since_parameter = False
 
     @property
     def http_headers(self) -> dict:
@@ -106,102 +317,43 @@ class DynamicStream(RestApiStream):
 
         return headers
 
-    def _get_next_page_token_default(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Optional[str]:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows the default style of getting the next page token from the
-        default path provided in the config or, if that doesn't exist, the header.
-
-        Args:
-            response: the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
+    def get_new_paginator(self):
+        """Return the requested paginator required to retrieve all data from the API.
 
         Returns:
-              A str representing the next page to be queried or `None`.
+              Paginator Class.
 
         """
-        if self.next_page_token_jsonpath:
-            all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
-            )
-            first_match = next(iter(all_matches), None)
-            next_page_token = first_match
+
+        self.logger.info(f"the next_page_token_jsonpath = {self.next_page_token_jsonpath}.")
+
+        if self.pagination_request_style == 'jsonpath_paginator' or self.pagination_request_style == 'default':
+            return JSONPathPaginator(self.next_page_token_jsonpath)
+        elif self.pagination_request_style == 'simple_header_paginator': # Example Gitlab.com
+            return SimpleHeaderPaginator('X-Next-Page')
+        elif self.pagination_request_style == 'header_link_paginator':
+            return HeaderLinkPaginator()
+        elif self.pagination_request_style == 'restapi_header_link_paginator': # Example GitHub.com
+            return RestAPIHeaderLinkPaginator(pagination_page_size=self.pagination_page_size,
+                                              pagination_results_limit=self.pagination_results_limit,
+                                              replication_key=self.replication_key)
+        elif self.pagination_request_style == 'style1' or self.pagination_request_style == 'offset_paginator':
+            return RestAPIOffsetPaginator(start_value=1,
+                                          page_size=self.pagination_page_size,
+                                          jsonpath=self.next_page_token_jsonpath)
+        elif self.pagination_request_style == 'hateoas_paginator':
+            return BaseHATEOASPaginator()
+        elif self.pagination_request_style == 'single_page_paginator':
+            return SinglePagePaginator()
+        elif self.pagination_request_style == 'page_number_paginator':
+            return RestAPIBasePageNumberPaginator(jsonpath=self.next_page_token_jsonpath)
         else:
-            next_page_token = response.headers.get("X-Next-Page", None)
-
-        return next_page_token
-
-    def _get_next_page_token_style1(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Any:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows method of calculating the next page token from the
-        offsets, limits, and totals provided by the API.
-
-        Args:
-            response: required - the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
-
-        Returns:
-              A str representing the next page to be queried or `None`.
-
-        """
-        pagination = response.json().get("pagination", {})
-        if pagination and all(x in pagination for x in ["offset", "limit", "total"]):
-            next_page_token = pagination["offset"] + pagination["limit"]
-            if next_page_token <= pagination["total"]:
-                return next_page_token
-        return None
-
-    def _get_next_page_token_hateoas_body(
-        self, response: requests.Response, previous_token: Optional[Any]
-    ) -> Any:
-        """Return a token for identifying next page or None if no more pages.
-
-        This method follows method of calculating the next page token from the
-        API response body itself following HATEOAS Rest model.
-
-
-        HATEOAS stands for "Hypermedia as the Engine of Application State". See
-        https://en.wikipedia.org/wiki/HATEOAS.
-
-        Args:
-            response: required - the requests.Response given by the api call.
-            previous_token: optional - the token representing the current/previous page
-                of results.
-
-        Returns:
-              A str representing the next page to be queried or `None`.
-
-        """
-
-        if self.next_page_token_jsonpath:
-
-            all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
+            self.logger.error(f"Unknown paginator {self.pagination_request_style}. Please declare a valid paginator.")
+            raise ValueError(
+                f"Unknown paginator {self.pagination_request_style}. Please declare a valid paginator."
             )
-            first_match = next(iter(all_matches), None)
-            next_page_token = first_match
 
-            # Setting up the url using next_page_token parameters
-            # for subsequent calls.
-            url_parsed = urlparse(next_page_token)
-            if url_parsed.path == next_page_token:
-                self.path = ""
-            else:
-                self.path=url_parsed.path
-
-        else:
-            next_page_token = response.headers.get("X-Next-Page", None)
-
-        return next_page_token
-
-    def _get_url_params_default(
+    def _get_url_params_page_style(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
@@ -219,13 +371,17 @@ class DynamicStream(RestApiStream):
             for k, v in self.params.items():
                 params[k] = v
         if next_page_token:
-            params["page"] = next_page_token
+            if self.pagination_next_page_param:
+                next_page_parm = self.pagination_next_page_param
+            else:
+                next_page_parm = "page"
+            params[next_page_parm] = next_page_token
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
         return params
 
-    def _get_url_params_style1(
+    def _get_url_params_offset_style(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization.
@@ -243,12 +399,81 @@ class DynamicStream(RestApiStream):
             for k, v in self.params.items():
                 params[k] = v
         if next_page_token:
-            params["offset"] = next_page_token
+            if self.pagination_next_page_param:
+                next_page_parm = self.pagination_next_page_param
+            else:
+                next_page_parm = "offset"
+            params[next_page_parm] = next_page_token
         if self.pagination_page_size is not None:
-            params["limit"] = self.pagination_page_size
+            if self.pagination_limit_per_page_param:
+                limit_per_page_param = self.pagination_limit_per_page_param
+            else:
+                limit_per_page_param = "limit"
+            params[limit_per_page_param] = self.pagination_page_size
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key
+        return params
+      
+    def _get_url_params_header_link(
+        self, context: Optional[Dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization.
+        Logic based on https://github.com/MeltanoLabs/tap-github
+
+        Args:
+            context: optional - the singer context object.
+            next_page_token: optional - the token for the next page of results.
+
+        Returns:
+            An object containing the parameters to add to the request.
+
+        """
+        params: dict = {}
+        if self.params:
+            for k, v in self.params.items():
+                params[k] = v
+        if self.pagination_page_size:
+            pagination_page_size = self.pagination_page_size
+        else:
+            pagination_page_size = 25 # Default to 25 per page if not set
+        if self.pagination_limit_per_page_param:
+            limit_per_page_param = self.pagination_limit_per_page_param
+        else:
+            limit_per_page_param = "per_page"
+        params[limit_per_page_param] = pagination_page_size
+        if next_page_token:
+            request_parameters = parse_qs(str(next_page_token))
+            for k, v in request_parameters.items():
+                params[k] = v            
+
+        if self.replication_key == "updated_at":
+            params["sort"] = "updated"
+            params["direction"] = "desc" if self.use_fake_since_parameter else "asc"
+
+        # Unfortunately the /starred, /stargazers (starred_at) and /events (created_at) endpoints do not support
+        # the "since" parameter out of the box. But we use a workaround in 'get_next_page_token'.
+        elif self.replication_key in ["starred_at", "created_at"]:
+            params["sort"] = "created"
+            params["direction"] = "desc"
+
+        # Warning: /commits endpoint accept "since" but results are ordered by descending commit_timestamp
+        elif self.replication_key == "commit_timestamp":
+            params["direction"] = "desc"
+
+        elif self.replication_key:
+            self.logger.warning(
+                f"The replication key '{self.replication_key}' is not fully supported by this client yet."
+            )
+
+        since = self.get_starting_timestamp(context)
+        since_key = "since" if not self.use_fake_since_parameter else "fake_since"
+        if self.replication_key and since:
+            params[since_key] = since
+            # Leverage conditional requests to save API quotas
+            # https://github.community/t/how-does-if-modified-since-work/139627
+            self._http_headers["If-modified-since"] = email.utils.format_datetime(since)
+
         return params
 
     def get_start_date(
@@ -278,8 +503,8 @@ class DynamicStream(RestApiStream):
             next_page_token: optional - the token for the next page of results.
 
 
-            HATEOAS stands for "Hypermedia as the Engine of Application State". See
-            https://en.wikipedia.org/wiki/HATEOAS.            
+            HATEOAS stands for "Hypermedia as the Engine of Application State".
+             See https://en.wikipedia.org/wiki/HATEOAS.            
 
             Note: Under the HATEOAS model, the returned token contains all the 
             required parameters for the subsequent call. The function splits the
@@ -298,6 +523,11 @@ class DynamicStream(RestApiStream):
         if self.params:
             for k, v in self.params.items():
                 params[k] = v
+                
+        # Set Pagination Limits if required.
+        if self.pagination_page_size and self.pagination_limit_per_page_param:
+            params[pagination_limit_per_page_param] = self.pagination_page_size
+                
         if next_page_token:
             # Parse the next_page_token for the path and parameters
             url_parsed = urlparse(next_page_token)

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -259,6 +259,8 @@ class DynamicStream(RestApiStream):
                 params["sort"] = "asc"
                 params["order_by"] = self.replication_key
 
+        return params
+
     def _get_url_params_offset_style(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -12,10 +12,10 @@ from tap_rest_api_msdk.client import RestApiStream
 from tap_rest_api_msdk.pagination import RestAPIHeaderLinkPaginator, RestAPIOffsetPaginator, RestAPIBasePageNumberPaginator
 from tap_rest_api_msdk.utils import flatten_json
 
+# Remove commented section to show http_request for debugging
 #import logging
 #import http.client
 
-# Remove commented section to show http_request for debugging
 #http.client.HTTPConnection.debuglevel = 1
 
 #logging.basicConfig()

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -5,194 +5,23 @@ from typing import Any, Dict, Iterable, Optional, cast
 
 import requests
 import email.utils
-from singer_sdk.pagination import SinglePagePaginator, BaseOffsetPaginator, BaseHATEOASPaginator, JSONPathPaginator, HeaderLinkPaginator, SimpleHeaderPaginator, BasePageNumberPaginator
 from singer_sdk.helpers.jsonpath import extract_jsonpath
+from tap_rest_api_msdk.pagination import SinglePagePaginator, BaseHATEOASPaginator, JSONPathPaginator, SimpleHeaderPaginator, RestAPIHeaderLinkPaginator, RestAPIOffsetPaginator, RestAPIBasePageNumberPaginator
 from tap_rest_api_msdk.client import RestApiStream
 from tap_rest_api_msdk.utils import flatten_json, unnest_dict
 from urllib.parse import urlparse, parse_qsl, parse_qs
 
-# import logging
-# import http.client
+import logging
+import http.client
 
-# http.client.HTTPConnection.debuglevel = 1
+# Remove commented section to show http_request for debugging
+#http.client.HTTPConnection.debuglevel = 1
 
-# logging.basicConfig()
-# logging.getLogger().setLevel(logging.DEBUG)
-# requests_log = logging.getLogger("requests.packages.urllib3")
-# requests_log.setLevel(logging.DEBUG)
-# requests_log.propagate = True
-
-class RestAPIBasePageNumberPaginator(BasePageNumberPaginator):
-    def __init__(
-        self,
-        *args,
-        jsonpath: str = None,
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self._jsonpath = jsonpath
-
-    def has_more(self, response: requests.Response):
-        """Return True if there are more pages to fetch.
-
-        Args:
-            response: The most recent response object.
-            jsonpath: An optional jsonpath to where the tokens are located in
-                      the response, defaults to `hasMore` in the response.
-
-        Returns:
-            Whether there are more pages to fetch.
-        """
-        
-        if self._jsonpath:
-            return next(extract_jsonpath(self._jsonpath, response.json()), None)
-        else:
-            return response.json().get("hasMore", None)
-
-class RestAPIOffsetPaginator(BaseOffsetPaginator):
-    def __init__(
-        self,
-        *args,
-        jsonpath: str = None,
-        pagination_total_limit_param: str,
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self.jsonpath = jsonpath
-        self.pagination_total_limit_param = pagination_total_limit_param
-
-    def has_more(self, response: requests.Response):
-        """Return True if there are more pages to fetch.
-
-        Args:
-            response: The most recent response object.
-            jsonpath: An optional jsonpath to where the tokens are located in
-                      the response, defaults to pagination in the response.
-
-        Returns:
-            Whether there are more pages to fetch.
-        """
-        
-        if self.jsonpath:
-            pagination = next(extract_jsonpath(self.jsonpath, response.json()), None)
-        else:
-            pagination = response.json().get("pagination", None)
-        if pagination:
-            pagination = unnest_dict(pagination)
-
-        if pagination and all(x in pagination for x in ["offset", "limit"]):
-            record_limit = pagination.get(self.pagination_total_limit_param,0)
-            records_read = pagination["offset"] + pagination["limit"]
-            if records_read <= record_limit:
-                return True
-
-        return False
-
-class RestAPIHeaderLinkPaginator(HeaderLinkPaginator):
-    def __init__(
-        self,
-        *args,
-        pagination_page_size: int = 25,
-        pagination_results_limit: Optional[int] = None,
-        use_fake_since_parameter: Optional[bool] = False,
-        replication_key: Optional[str] = None,
-        **kwargs
-    ):
-        super().__init__(*args, **kwargs)
-        self.pagination_page_size = pagination_page_size
-        self.pagination_results_limit = pagination_results_limit
-        self.use_fake_since_parameter = use_fake_since_parameter
-        self.replication_key = replication_key
-
-    def get_next_url(
-        self, response: requests.Response
-    ) -> Optional[Any]:
-        """Return next page parameter(s) for identifying the next page
-           or None if no more pages.
-           
-           Logic based on https://github.com/MeltanoLabs/tap-github
-           
-        Args:
-            response: The most recent response object.
-            pagination_page_size: A limit for records per page. Default=25
-            pagination_results_limit: A limit to the number of pages returned
-            use_fake_since_parameter: A work around for GitHub. default=False
-            replication_key: Key for incremental processing
-
-        Returns:
-            Page Parameters if there are more pages to fetch, else None.
-        """
-        # Exit if the set Record Limit is reached.
-        if (
-            self._page_count
-            and self.pagination_results_limit
-            and (
-                cast(int, self._page_count) * self.pagination_page_size >= self.pagination_results_limit
-            )
-        ):
-            return None
-          
-        # Leverage header links returned by the GitHub API.
-        if "next" not in response.links.keys():
-            return None
-
-        # Exit early if there is no URL in the next links
-        if not response.links.get("next",{}).get("url"):
-            return None
-
-        resp_json = response.json()
-        if isinstance(resp_json, list):
-            results = resp_json
-        else:
-            results = resp_json.get("items")
-
-        # Exit early if the response has no items. ? Maybe duplicative the "next" link check.
-        if not results:
-            return None
-          
-        # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
-        # the "since" parameter out of the box. So we use a workaround here to exit early.
-        # For such streams, we sort by descending dates (most recent first), and paginate
-        # "back in time" until we reach records before our "fake_since" parameter.
-        if self.replication_key and self.use_fake_since_parameter:
-            request_parameters = parse_qs(str(urlparse(response.request.url).query))
-            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
-            try:
-                since = (
-                    request_parameters["fake_since"][0].replace(" ", "+")
-                    if "fake_since" in request_parameters
-                    else ""
-                )
-            except IndexError:
-                return None
-
-            direction = (
-                request_parameters["direction"][0]
-                if "direction" in request_parameters
-                else None
-            )
-
-            # commit_timestamp is a constructed key which does not exist in the raw response
-            replication_date = (
-                results[-1][self.replication_key]
-                if self.replication_key != "commit_timestamp"
-                else results[-1]["commit"]["committer"]["date"]
-            )
-            # exit early if the replication_date is before our since parameter
-            if (
-                since
-                and direction == "desc"
-                and (parse(replication_date) < parse(since))
-            ):
-                return None
-
-        # Use header links returned by the API to return the query parameters.
-        parsed_url = urlparse(response.links["next"]["url"])
-
-        if parsed_url.query:
-            return(parsed_url.query)
-          
-        return None
+#logging.basicConfig()
+#logging.getLogger().setLevel(logging.DEBUG)
+#requests_log = logging.getLogger("requests.packages.urllib3")
+#requests_log.setLevel(logging.DEBUG)
+#requests_log.propagate = True
 
 
 class DynamicStream(RestApiStream):
@@ -206,7 +35,6 @@ class DynamicStream(RestApiStream):
         path: str,
         params: Optional[dict] = None,
         headers: Optional[dict] = None,
-        auth: Optional[Any] = None, # TODO: remove when refactored into SDK
         primary_keys: Optional[list] = None,
         replication_key: Optional[str] = None,
         except_keys: Optional[list] = None,
@@ -231,7 +59,6 @@ class DynamicStream(RestApiStream):
             path: see tap.py
             params: see tap.py
             headers: see tap.py
-            auth: Optional http requests auth set by Authenticator in tap.py : TODO remove when refactored
             primary_keys: see tap.py
             replication_key: see tap.py
             except_keys: see tap.py
@@ -259,7 +86,6 @@ class DynamicStream(RestApiStream):
         self.path = path
         self.params = params
         self.headers = headers
-        self.http_auth = auth  # TODO: remove when refactored into SDK
         self.primary_keys = primary_keys
         self.replication_key = replication_key
         self.except_keys = except_keys
@@ -337,47 +163,6 @@ class DynamicStream(RestApiStream):
 
         return headers
 
-    # TODO: This SDK function has been included and overloaded because we need to
-    # pass in auth to the request. Would like this as an enhancement to the SDK.
-    #
-    # Would like to remove this function to have a vanilla implementation.
-    def prepare_request(
-        self,
-        context: Optional[dict], # Replaced to remove Type Error
-        next_page_token: Optional[Any] # Replaced to remove Type Error
-#        context: dict | None,
-#        next_page_token: _TToken | None,
-    ) -> requests.PreparedRequest:
-        """Prepare a request object for this stream.
-
-        If partitioning is supported, the `context` object will contain the partition
-        definitions. Pagination information can be parsed from `next_page_token` if
-        `next_page_token` is not None.
-
-        Args:
-            context: Stream partition or context dictionary.
-            next_page_token: Token, page number or any request argument to request the
-                next page of data.
-
-        Returns:
-            Build a request with the stream's URL, path, query parameters,
-            HTTP headers and authenticator.
-        """
-        http_method = self.rest_method
-        url: str = self.get_url(context)
-        params: dict | str = self.get_url_params(context, next_page_token)
-        request_data = self.prepare_request_payload(context, next_page_token)
-        headers = self.http_headers
-        auth = self.http_auth  # Extended Meltano SDK with this line
-
-        return self.build_prepared_request(
-            method=http_method,
-            url=url,
-            auth=auth, # Extended Meltano SDK with this line
-            params=params,
-            headers=headers,
-            json=request_data,
-        )
 
     def get_new_paginator(self):
         """Return the requested paginator required to retrieve all data from the API.

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -116,7 +116,7 @@ class TapRestApiMsdk(Tap):
             required=False,
             description="An optional query template to be issued against the API."
             "Substitute the query field you are querying against with $last_run_date. At"
-            "run-time, the tap will dynamically update the token with either the `start_date`
+            "run-time, the tap will dynamically update the token with either the `start_date`"
             "or the last bookmark / state value. A simple template Example for FHIR API's: "
             "gt$last_run_date. A more complex example against an Opensearch API, "
             "{\"bool\": {\"filter\": [{\"range\": { \"meta.lastUpdated\": { \"gt\": \"$last_run_date\" }}}] }} ."

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -9,9 +9,9 @@ from genson import SchemaBuilder
 from singer_sdk import Tap
 from singer_sdk import typing as th
 from singer_sdk.helpers.jsonpath import extract_jsonpath
+from tap_rest_api_msdk.auth import select_authenticator
 from tap_rest_api_msdk.streams import DynamicStream
 from tap_rest_api_msdk.utils import flatten_json
-from tap_rest_api_msdk.auth import AWSConnectClient, select_authenticator
 
 class TapRestApiMsdk(Tap):
     """rest-api tap class."""
@@ -483,6 +483,7 @@ class TapRestApiMsdk(Tap):
             authenticator = select_authenticator(self)
             if hasattr(authenticator, "auth_headers"):
                 headers.update(authenticator.auth_headers or {})
+            if hasattr(authenticator, "auth_params"):
                 params.update(authenticator.auth_params or {})
 
         r = requests.get(self.config["api_url"] + path, auth=self.http_auth, params=params, headers=headers)

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -353,6 +353,13 @@ class TapRestApiMsdk(Tap):
             required=False,
             description="The name of the param that indicates the limit/per_page. Defaults to None",
         ),
+        th.Property(
+            "pagination_total_limit_param",
+            th.StringType,
+            default="total",
+            required=False,
+            description="The name of the param that indicates the total limit e.g. total, count. Defaults to total",
+        ),
     )
 
     # add common properties to top-level properties
@@ -471,6 +478,7 @@ class TapRestApiMsdk(Tap):
                     pagination_results_limit=self.config.get("pagination_results_limit"),
                     pagination_next_page_param=self.config.get("pagination_next_page_param"),
                     pagination_limit_per_page_param=self.config.get("pagination_limit_per_page_param"),
+                    pagination_total_limit_param=self.config.get("pagination_total_limit_param"),
                     schema=schema,
                     start_date=start_date,
                     search_parameter=search_parameter,

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -95,8 +95,9 @@ class TapRestApiMsdk(Tap):
             "start_date",
             th.DateTimeType,
             required=False,
-            description="An optional initial starting date when using a date based "
-            "replication key and there is no state available.",
+            description="An optional field. Normally required when using the"
+            "replication_key. This is the initial starting date when using a"
+            "date based replication key and there is no state available.",
         ),
         th.Property(
             "source_search_field",
@@ -107,17 +108,17 @@ class TapRestApiMsdk(Tap):
             "incrementally processing from a previous state. Example `last-updated`. "
             "Note: You must also set the replication_key, where the replication_key is"
             "json response representation of the API `source_search_field`. You should"
-            "also supply the `source_search_query`.",
+            "also supply the `source_search_query`, `replication_key` and `start_date`.",
         ),
         th.Property(
             "source_search_query",
             th.StringType,
             required=False,
             description="An optional query template to be issued against the API."
-            "Change the query field you are querying against with $last_run_date. At"
-            "run-time, the tap will substitute in either the `start_date` or the"
-            "last bookmark / state value. A simple template Example for FHIR API's: "
-            "gt$last_run_date . A more complex example against an Opensearch API, "
+            "Substitute the query field you are querying against with $last_run_date. At"
+            "run-time, the tap will dynamically update the token with either the `start_date`
+            "or the last bookmark / state value. A simple template Example for FHIR API's: "
+            "gt$last_run_date. A more complex example against an Opensearch API, "
             "{\"bool\": {\"filter\": [{\"range\": { \"meta.lastUpdated\": { \"gt\": \"$last_run_date\" }}}] }} ."
             "Note: Any required double quotes in the query template must be escaped.",
         ),
@@ -285,9 +286,9 @@ class TapRestApiMsdk(Tap):
             th.BooleanType,
             default=False,
             required=False,
-            description="send the request parameters in the request body."
-            "This is normally not required, a few API's require this like"
-            "OpenSearch. Defaults to `False`",
+            description="sends the request parameters in the request body."
+            "This is normally not required, a few API's like OpenSearch"
+            "require this. Defaults to `False`",
         ),
         th.Property(
             "pagination_page_size",

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -66,6 +66,17 @@ def flatten_json(obj: dict, except_keys: Optional[list] = None) -> dict:
     return out
     
 def unnest_dict(d):
+    """Flattens a dict object by create a new object with the key value pairs.
+
+    Recursive flattening any nested dicts to a single level.
+
+    Args:
+        obj: the dict object to be flattened.
+
+    Returns:
+        A flattened dict object.
+
+    """
     result = {}
     for k,v in d.items():
         if isinstance(v, dict):

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -65,11 +65,11 @@ def flatten_json(obj: dict, except_keys: Optional[list] = None) -> dict:
     flatten(obj, exception_keys=except_keys)
     return out
     
-def compress_dict(dic: dict):
-    result ={}
-    for k,v in dic.items():
+def unnest_dict(d):
+    result = {}
+    for k,v in d.items():
         if isinstance(v, dict):
-            compress_dict(v)
+            result.update(unnest_dict(v))
         else:
-            result.update({k:v})
+            result[k] = v
     return result

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -64,3 +64,12 @@ def flatten_json(obj: dict, except_keys: Optional[list] = None) -> dict:
 
     flatten(obj, exception_keys=except_keys)
     return out
+    
+def compress_dict(dic: dict):
+    result ={}
+    for k,v in dic.items():
+        if isinstance(v, dict):
+            compress_dict(v)
+        else:
+            result.update({k:v})
+    return result

--- a/tap_rest_api_msdk/utils.py
+++ b/tap_rest_api_msdk/utils.py
@@ -84,3 +84,23 @@ def unnest_dict(d):
         else:
             result[k] = v
     return result
+
+def get_start_date(
+    self,
+    context: dict
+) -> Any:
+    """Returns a start date if a DateTime bookmark is available.
+    Otherwise it returns the starting date as defined in 
+    the start_date parameter.
+
+    Args:
+        context: - the singer context object.
+
+    Returns:
+        An start date else and empty string.
+
+    """
+    try:
+        return self.get_starting_timestamp(context).strftime("%Y-%m-%dT%H:%M:%S")
+    except (ValueError, AttributeError):
+        return self.get_starting_replication_key_value(context)


### PR DESCRIPTION
This PR introduces new Authenticators and Paginators to `tap-rest-api-msdk`. (it is a refactored approach to previous PR's). With this feature there is greater support for a range of API's  - making this tap the swiss army knife for accessing API's.

# Summary

- Support for most Meltano SDK Authenticators.
- Support for all Meltano Paginators.
- Flexibility to support many new API's by new settings to adjust request parameter names. See README.md for more details on settings.
- Ability to send parameters in the request body rather than request parameters (if required).
- Moving from deprecated `get_next_page_token` to support `get_new_paginator`. This removes the warnings in the logs.
- Enhanced incremental replication (include support for API query templates).
- New modules `auth` and `pagination` keeping a clean design.
- New `auth` method aws, to support ingestion from AWS REST End-point e.g. OpenSearch.


# Paginators

Each REST API is different. This PR builds on the concept of picking an appropriate request and response style for the API. Select an appropriate `pagination_request_style` to pick the paginator you require. In most cases this needs to be coupled with an appropriate `paginator_response_style` to process the response and pick the next page location in the body or headers.

Supported Paginators as part of this PR include:

- `jsonpath_paginator` or `default` - This style obtains the token for the next page from a specific location in the response body via JSONPath notation. In many situations the `jsonpath_paginator` is a more appropriate paginator to the `hateoas_paginator`.
  - `next_page_token_path` - The jsonpath to next page token. Example: `"$['@odata.nextLink']"`, this locates the token returned via the Microsoft Graph API. Default `'$.next_page'` for the `jsonpath_paginator` paginator only otherwise None.
- `offset_paginator` or `style1` - This style uses URL parameters named offset and limit
  - `offset` is calculated from the previous response, or not set if there is no previous response
  - `pagination_page_size` - Sets a limit to number of records per page / response. Default `25` records.
  - `pagination_limit_per_page_param` - the name of the API parameter to limit number of records per page. Default parameter name `limit`.
  - `pagination_total_limit_param` - The name of the param that indicates the total limit e.g. total, count. Defaults to total
  - `next_page_token_path` - Used to locate an appropriate link in the response. Default None - but looks in the `pagination` section of the JSON response by default. Example, jsonpath to get the offset from the NOAA API `'$.metadata.resultset'`.
- `simple_header_paginator` - This style uses links in the Header Response to locate the next page. Example the `x-next-page` link used by the Gitlab API.
- `header_link_paginator` - This style uses the default header link paginator from the Meltano SDK.
- `restapi_header_link_paginator` - This style is a variant on the header_link_paginator. It supports the ability to read from GitHub API.
  - `pagination_page_size` - Sets a limit to number of records per page / response. Default `25` records.
  - `pagination_limit_per_page_param` - the name of the API parameter to limit number of records per page. Default parameter name `per_page`.
  - `pagination_results_limit` - Restricts the total number of records returned from the API. Default None i.e. no limit.
- `hateoas_paginator` - This style parses the next_token response for the parameters to pass. It is used by API's utilising the HATEOAS Rest style [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS), including [FHIR API's](https://hl7.org/fhir/http.html).
  - `pagination_page_size` - Sets a limit to number of records per page / response. Default None.
  - `pagination_limit_per_page_param` - the name of the API parameter to limit number of records per page e.g. `_count` for [FHIR API's](https://hl7.org/fhir/http.html). Default None.
- `single_page_paginator` - A paginator that does works with single-page endpoints.
- `page_number_paginator` - Paginator class for APIs that use page number. Looks at the response link to determine more pages.
  - `next_page_token_path` - Use to locate an appropriate link in the response. Default `"hasMore"`.

# Authentication

This PR introduces many additional forms of authentication that weren't possible with just headers in the request (for example OAuth).

The Meltano SDK introduced a number of authentication methods, which have been supported with this feature. The feature utilizes the available SDK Authenticators https://github.com/meltano/sdk/blob/main/singer_sdk/authenticators.py.

While new auth methods are supported, by default for legacy support, you can still pass Authentication via headers, there is no breaking changes as a result. New supported authenticators :

  - **oauth**: for OAuth2 authentication
  - **basic**: Basic Header authentication - base64-encoded username + password config items
  - **api_key**: for API Keys in the header e.g. X-API-KEY.
  - **bearer_token**: for Bearer token authentication.
  - **aws**: for AWS authentication. Works with the `aws_credentials` parameter.

Please note that support for OAuthJWTAuthentication has not been developed.

Other Changes:
- Fixes to the meltano.yml kind / data types.
- Updated meltano.yml with all the available parameters.
- Adds a config.json.sample file for illustrating how to construct a config.json file when using the tap stand-alone for development purposes.
- Documentation for new settings and examples of use against a number of API's.

Note: I am aware that there are no supported API tests as they are time consuming to build and test. I have however with my limited time tested against of variety of API's available to me. Perhaps `faker` python package to help simulate tests for a variety of API's and responses. This appears to be used by tap-dbt https://github.com/MeltanoLabs/tap-dbt/blob/main/tests/test_core.py