### PR TITLE
Feature/sdk supported oauth headers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "<3.12,>=3.7.1"
 requests = "^2.25.1"
-singer-sdk = "^0.26.0"
+#singer-sdk = "^0.26.0"
 singer-sdk = { git = "https://github.com/s7clarke10/sdk.git", branch = "feature/support_headers_when_requesting_oauth_token" }
 genson = "^1.2.2"
 atomicwrites = "^1.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "<3.12,>=3.7.1"
 requests = "^2.25.1"
-#singer-sdk = "^0.26.0"
-singer-sdk = { git = "https://github.com/meltano/sdk.git", rev = "1637b48" }
+singer-sdk = "^0.30.0"
 genson = "^1.2.2"
 atomicwrites = "^1.4.0"
 requests-aws4auth = "^1.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ readme = "README.md"
 python = "<3.12,>=3.7.1"
 requests = "^2.25.1"
 singer-sdk = "^0.26.0"
+singer-sdk = { git = "https://github.com/s7clarke10/sdk.git", branch = "feature/support_headers_when_requesting_oauth_token" }
 genson = "^1.2.2"
 atomicwrites = "^1.4.0"
 requests-aws4auth = "^1.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ readme = "README.md"
 python = "<3.12,>=3.7.1"
 requests = "^2.25.1"
 #singer-sdk = "^0.26.0"
-singer-sdk = { git = "https://github.com/s7clarke10/sdk.git", branch = "feature/support_headers_when_requesting_oauth_token" }
+singer-sdk = { git = "https://github.com/meltano/sdk.git", rev = "1637b48" }
 genson = "^1.2.2"
 atomicwrites = "^1.4.0"
 requests-aws4auth = "^1.2.3"

--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import boto3
 from requests_aws4auth import AWS4Auth
-from singer_sdk.authenticators import APIKeyAuthenticator, BasicAuthenticator, BearerTokenAuthenticator, OAuthAuthenticator
+from singer_sdk.authenticators import (
+    APIKeyAuthenticator,
+    BasicAuthenticator,
+    BearerTokenAuthenticator,
+    OAuthAuthenticator
+)
 
 class AWSConnectClient:
     """A connection class to AWS Resources"""
@@ -195,6 +200,11 @@ def select_authenticator(self) -> Any:
     api_keys = my_config.get('api_keys', '')
     self.http_auth = None
 
+    # Set http headers if headers are supplied
+    # Some OAUTH2 API's require headers to be supplied
+    # In the OAUTH request.
+    auth_headers = my_config.get('headers',None)
+
     # Using API Key Authenticator, keys are extracted from api_keys dict
     if auth_method == "api_key":
         if api_keys:
@@ -220,6 +230,7 @@ def select_authenticator(self) -> Any:
             auth_endpoint=my_config.get('access_token_url', ''),
             oauth_scopes=my_config.get('scope', ''),
             default_expiration=my_config.get('oauth_expiration_secs', ''),
+            auth_headers=auth_headers,
         )
     # Using Bearer Token Authenticator
     elif auth_method == "bearer_token":

--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -230,7 +230,7 @@ def select_authenticator(self) -> Any:
             auth_endpoint=my_config.get('access_token_url', ''),
             oauth_scopes=my_config.get('scope', ''),
             default_expiration=my_config.get('oauth_expiration_secs', ''),
-            auth_headers=auth_headers,
+            oauth_headers=auth_headers,
         )
     # Using Bearer Token Authenticator
     elif auth_method == "bearer_token":

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -16,6 +16,8 @@ class RestApiStream(RESTStream):
 
     # Intialise self.http_auth used by prepare_request
     http_auth = None
+    # Cache the authenticator using a Smart Singleton pattern 
+    _authenticator = None
 
     @property
     def url_base(self) -> Any:
@@ -29,7 +31,6 @@ class RestApiStream(RESTStream):
       
 
     @property
-    @cached
     def authenticator(self) -> Any:
         """Calls an appropriate SDK Authentication method based on the the set auth_method
         which is set via the config.
@@ -39,9 +40,8 @@ class RestApiStream(RESTStream):
         Note 1: Each auth method requires certain configuration to be present see README.md
         for each auth methods configuration requirements.
         
-        Note 2: The cached decorator will have all calls to the authenticator use the
-        same instance logic to speed up processing. TODO: Examine if this affects OAuth2
-        callbacks and if logic is required for callback for expiring AWS STS tokens.
+        Note 2: Using Singleton Pattern on the autenticator for caching with a check
+        if an OAuth Token has expired and needs to be refreshed.
 
         Raises:
             ValueError: if the auth_method is unknown.
@@ -50,11 +50,16 @@ class RestApiStream(RESTStream):
             A SDK Authenticator or APIAuthenticatorBase if no auth_method supplied.
         """
 
-        stream_authenticator = select_authenticator(self)
-        
-        if stream_authenticator:
-            return stream_authenticator
-        else:
-            return APIAuthenticatorBase(stream=self)
-          
+        auth_method = self.config.get("auth_method",None)
 
+        if not self._authenticator:
+            self._authenticator = select_authenticator(self)         
+            if not self._authenticator:
+                # No Auth Method, use default Authenticator
+                self._authenticator = APIAuthenticatorBase(stream=self)           
+        elif auth_method == 'oauth':
+            if not self._authenticator.is_token_valid():
+                # Obtain a new OAuth token as it has expired
+                self._authenticator = select_authenticator(self)
+
+        return self._authenticator


### PR DESCRIPTION
This feature uses a new capability in the Meltano SDK [0.30.0](https://github.com/meltano/sdk/releases/tag/v0.30.0) to support Auth Headers when requesting an OAuth Token.

This feature was added in response to the new FHIR API which required a subscription key as a request header as part of the call to obtain an OAuth Token.

Changes.

1. Supplying headers when making an OAuth request
2. New Meltano SDK version 0.30.0